### PR TITLE
developer that work in windows OS as an issue with the ant build...

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -193,7 +193,7 @@ pte.version = ${i18neditor.version}
 
   <!-- Not used: For later installer.... see http://izpack.org/ -->
   <target name="check-izpack" depends="init">
-      <available property="izpack.present" 
+      <available property="izpack.present"
                  classname="com.izforge.izpack.ant.IzPackTask"
                  classpathref="installer.cp" />
       <fail unless="izpack.present">
@@ -219,7 +219,7 @@ pte.version = ${i18neditor.version}
         <srcfilelist dir="${basedir}" files="build.xml" />
         <targetfilelist dir="${classes}" files="${version.info}" />
       </dependset>
-      <copy file="${java.src}/${version.info}.in" 
+      <copy file="${java.src}/${version.info}.in"
             tofile="${classes}/${version.info}">
         <filterset>
           <filter token="VERSION" value="${version}" />
@@ -228,16 +228,17 @@ pte.version = ${i18neditor.version}
           <filter token="COPYRIGHT" value="${copyright}" />
         </filterset>
       </copy>
-      
+
       <javac srcdir="${java.src}"
              destdir="${classes}"
              classpathref="classpath"
-             debug="${debug}" 
+             debug="${debug}"
              optimize="${optimize}"
              includeantruntime="false"
-             deprecation="${deprecation}" />
+             deprecation="${deprecation}"
+      		 encoding="iso-8859-1"/>
   </target>
- 
+
   <!-- Create two jars: client and server (which depends on client because bots are clients) -->
   <target name="build" depends="compile"
           description="Create project jar files.">
@@ -291,10 +292,10 @@ pte.version = ${i18neditor.version}
 
   <target name="unused_old_example_test" depends="unused_old_example_compile-tests">
       <mkdir dir="${test.reports}" />
-      <junit dir="./" 
-             failureproperty="test.failure" 
-             printSummary="yes" 
-             fork="true" 
+      <junit dir="./"
+             failureproperty="test.failure"
+             printSummary="yes"
+             fork="true"
              haltonerror="no">
         <sysproperty key="basedir" value="." />
         <formatter type="xml" />
@@ -331,7 +332,7 @@ pte.version = ${i18neditor.version}
              deprecation="${deprecation}" />
   </target>
 
-   
+
   <!-- ************************************** -->
   <!-- Distribution targets -->
   <!-- These create top-level dist/ dir if not already present -->
@@ -543,7 +544,7 @@ pte.version = ${i18neditor.version}
                doctitle="${Name}, v ${version}, API Specification"
                windowtitle="${Name} v${version} API"
                access="package"
-               source="1.4" 
+               source="1.4"
                additionalparam="-breakiterator">
         <packageset dir="${java.src}" />
         <header><![CDATA[<b><a target="_blank" href="${url}">${Name} v${version} API</a></b><br><font size="-2">Built ${date}</font>]]></header>
@@ -556,7 +557,7 @@ pte.version = ${i18neditor.version}
   <!-- ************************************** -->
 
   <!-- Delete all artifacts of the project, i.e. ${target} & ${dist} -->
-  <target name="clean" depends="init" 
+  <target name="clean" depends="init"
           description="Cleans the project of all generated files">
       <delete quiet="true" includeEmptyDirs="true">
         <fileset dir="${target}/" defaultExcludes="no" />

--- a/src/java/soc/client/NotifyDialog.java
+++ b/src/java/soc/client/NotifyDialog.java
@@ -78,7 +78,7 @@ class NotifyDialog extends AskDialog
      *                 or null to look for cli's Frame as parent
      * @param promptText  Prompt text appearing above button; also used for the dialog title.
      *                 If multiple lines, first line is title; if begins with \n, title is "JSettlers".
-     * @param btnText  Button text
+     * @param btnText  Button text, or null for "OK"
      * @param hasDefault  Button is default (responds to Enter)
      * @throws IllegalArgumentException If cli or btnText is null
      */
@@ -89,7 +89,8 @@ class NotifyDialog extends AskDialog
        	          ? gamePI
        	          : getParentFrame(cli)),
         	promptText, promptText,
-            btnText, hasDefault);
+            (btnText != null) ? btnText : strings.get("base.ok"),
+            hasDefault);
     }
 
     /**


### PR DESCRIPTION
same of the file are pushed in the github repository with the iso-8859-1
encoding, but ant by default will use the cp1252  in windows environment

a bug fix for now can be to force javac to use the correct encoding in
the build.xml