### PR TITLE
Split SOCBoard into Standard4p and Standard6p. Tidy up SOCBoard.

### DIFF
--- a/src/main/java/soc/baseclient/SOCDisplaylessPlayerClient.java
+++ b/src/main/java/soc/baseclient/SOCDisplaylessPlayerClient.java
@@ -23,25 +23,7 @@ package soc.baseclient;
 
 import soc.disableDebug.D;
 
-import soc.game.SOCBoard;
-import soc.game.SOCBoardLarge;
-import soc.game.SOCCity;
-import soc.game.SOCDevCardConstants;
-import soc.game.SOCFortress;
-import soc.game.SOCGame;
-import soc.game.SOCGameOption;
-import soc.game.SOCInventory;
-import soc.game.SOCInventoryItem;
-import soc.game.SOCPlayer;
-import soc.game.SOCPlayingPiece;
-import soc.game.SOCResourceConstants;
-import soc.game.SOCResourceSet;
-import soc.game.SOCRoad;
-import soc.game.SOCSettlement;
-import soc.game.SOCShip;
-import soc.game.SOCSpecialItem;
-import soc.game.SOCTradeOffer;
-import soc.game.SOCVillage;
+import soc.game.*;
 
 import soc.message.*;
 
@@ -1139,8 +1121,7 @@ public class SOCDisplaylessPlayerClient implements Runnable
 
         SOCBoard bd = ga.getBoard();
         final int bef = mes.getBoardEncodingFormat();
-        bd.setBoardEncodingFormat(bef);
-        if (bef == SOCBoard.BOARD_ENCODING_LARGE)
+        if (bef == SOCBoardLarge.BOARD_ENCODING_LARGE)
         {
             // v3
             ((SOCBoardLarge) bd).setLandHexLayout(mes.getIntArrayPart("LH"));
@@ -1171,7 +1152,7 @@ public class SOCDisplaylessPlayerClient implements Runnable
             if (others != null)
                 ((SOCBoardLarge) bd).setAddedLayoutParts(others);
         }
-        else if (bef <= SOCBoard.BOARD_ENCODING_6PLAYER)
+        else if (bef <= Standard6p.BOARD_ENCODING_6PLAYER)
         {
             // v1 or v2
             bd.setHexLayout(mes.getIntArrayPart("HL"));

--- a/src/main/java/soc/client/SOCBoardPanel.java
+++ b/src/main/java/soc/client/SOCBoardPanel.java
@@ -22,19 +22,7 @@
  **/
 package soc.client;
 
-import soc.game.SOCBoard;
-import soc.game.SOCBoardLarge;
-import soc.game.SOCCity;
-import soc.game.SOCFortress;
-import soc.game.SOCGame;
-import soc.game.SOCGameOption;
-import soc.game.SOCInventoryItem;
-import soc.game.SOCPlayer;
-import soc.game.SOCPlayingPiece;
-import soc.game.SOCRoad;
-import soc.game.SOCSettlement;
-import soc.game.SOCShip;
-import soc.game.SOCVillage;
+import soc.game.*;
 import soc.message.SOCSimpleRequest;  // to request simple things from the server without defining a lot of methods
 import soc.util.SOCStringManager;
 
@@ -687,7 +675,7 @@ public class SOCBoardPanel extends Canvas implements MouseListener, MouseMotionL
     /**
      * The board is configured for 6-player layout (and is {@link #isRotated});
      * set in constructor by checking {@link SOCBoard#getBoardEncodingFormat()}
-     * &lt;= {@link SOCBoard#BOARD_ENCODING_6PLAYER} and {@link SOCGame#maxPlayers} &gt; 4.
+     * &lt;= {@link Standard6p#BOARD_ENCODING_6PLAYER} and {@link SOCGame#maxPlayers} &gt; 4.
      *<P>
      * The entire coordinate system is land, except the rightmost hexes are unused
      * (7D-DD-D7 row).
@@ -1385,13 +1373,13 @@ public class SOCBoardPanel extends Canvas implements MouseListener, MouseMotionL
         board = game.getBoard();
         isScaled = false;
         scaledMissedImage = false;
-        if (board.getBoardEncodingFormat() == SOCBoard.BOARD_ENCODING_LARGE)
+        if (board.getBoardEncodingFormat() == SOCBoardLarge.BOARD_ENCODING_LARGE)
         {
             is6player = false;
             isLargeBoard = true;
             isRotated = isScaledOrRotated = false;
         } else {
-            is6player = (board.getBoardEncodingFormat() == SOCBoard.BOARD_ENCODING_6PLAYER)
+            is6player = (board.getBoardEncodingFormat() == Standard6p.BOARD_ENCODING_6PLAYER)
                 || (game.maxPlayers > 4);
             isLargeBoard = false;
             isRotated = isScaledOrRotated = is6player;
@@ -6687,7 +6675,7 @@ public class SOCBoardPanel extends Canvas implements MouseListener, MouseMotionL
      * because {@link #hexes} is static for all boards and all game options.
      * @param c  Our component, to load image resource files with getToolkit and getResource
      * @param wantsRotated  True for the 6-player non-sea board
-     *          (v2 encoding {@link SOCBoard#BOARD_ENCODING_6PLAYER}), false otherwise.
+     *          (v2 encoding {@link Standard6p#BOARD_ENCODING_6PLAYER}), false otherwise.
      *          The large board (v3 encoding)'s fog-hex and gold-hex images have no rotated version,
      *          because that board layout is never rotated.
      */

--- a/src/main/java/soc/game/SOCBoard.java
+++ b/src/main/java/soc/game/SOCBoard.java
@@ -136,8 +136,8 @@ import java.util.Vector;
  * share the same grid of coordinates.
  * Each hex is 2 units wide, in a 2-D coordinate system.
  *<P>
- * Current coordinate encodings: v1 ({@link #BOARD_ENCODING_ORIGINAL}),
- *   v2 ({@link #BOARD_ENCODING_6PLAYER}), v3 ({@link #BOARD_ENCODING_LARGE}).
+ * Current coordinate encodings: v1 ({@link Standard4p#BOARD_ENCODING_ORIGINAL}),
+ *   v2 ({@link Standard6p#BOARD_ENCODING_6PLAYER}), v3 ({@link SOCBoardLarge#BOARD_ENCODING_LARGE}).
  *<P>
  * <b>On the 4-player board:</b> See <tt>src/docs/hexcoord.gif</tt><br>
  * Coordinates start with hex (1,1) on the far west, and go to (D,D) on the east.
@@ -158,7 +158,7 @@ import java.util.Vector;
  * hex (B,B) is the southernmost land hex.  The ring of water hexes are outside
  * this coordinate grid.
  *<P>
- * For the large sea board (encoding v3: {@link #BOARD_ENCODING_LARGE}), see subclass {@link SOCBoardLarge}.
+ * For the large sea board (encoding v3: {@link SOCBoardLarge#BOARD_ENCODING_LARGE}), see subclass {@link SOCBoardLarge}.
  * Remember that ship pieces extend the {@link SOCRoad} class.
  * Most methods of {@link SOCBoard}, {@link SOCGame} and {@link SOCPlayer} differentiate them
  * ({@link SOCPlayer#hasPotentialRoad()} vs {@link SOCPlayer#hasPotentialShip()}),
@@ -173,13 +173,9 @@ import java.util.Vector;
  * @author Robert S Thomas
  * @see SOCBoardLarge
  */
-public class SOCBoard implements Serializable, Cloneable
+public abstract class SOCBoard implements Serializable, Cloneable
 {
     private static final long serialVersionUID = 2000L;  // last structural change v2.0.00
-
-    //
-    // Hex types
-    //
 
     /**
      * Water hex; lower-numbered than all land hex types.
@@ -276,159 +272,11 @@ public class SOCBoard implements Serializable, Cloneable
     public static final int FACING_NE = 1, FACING_E = 2, FACING_SE = 3,
         FACING_SW = 4, FACING_W = 5, FACING_NW = 6;
 
-    /**
-     * Port Placement constants begin here
-     * ------------------------------------------------------------------------------------
-     */
-
-    /**
-     * Each port's type, such as {@link #SHEEP_PORT}, on standard board.
-     * Same order as {@link #PORTS_FACING_V1}. {@link #MISC_PORT} is 0.
-     * @since 1.1.08
-     */
-    protected final static int PORTS_TYPE_V1[] = { 0, 0, 0, 0, CLAY_PORT, ORE_PORT, SHEEP_PORT, WHEAT_PORT, WOOD_PORT};
-
-    /**
-     * Each port's hex number within {@link #hexLayout} on standard board.
-     * Same order as {@link #PORTS_FACING_V1}:
-     * Clockwise from upper-left (hex coordinate 0x17).
-     * @since 1.1.08
-     */
-    private final static int PORTS_HEXNUM_V1[] = { 0, 2, 8, 21, 32, 35, 33, 22, 9 };
-
-    /**
-     * Each port's <em>facing</em> towards land, on the standard board.
-     * Ordered clockwise from upper-left (hex coordinate 0x17).
-     * Port Facing is the direction from the port hex/edge, to the land hex touching it
-     * which will have 2 nodes where a port settlement/city can be built.
-     * Facing 2 is east ({@link #FACING_E}), 3 is SE, 4 is SW, etc; see {@link #hexLayout}.
-     * @since 1.1.08
-     */
-    private final static int PORTS_FACING_V1[] =
-    {
-        FACING_SE, FACING_SW, FACING_SW, FACING_W, FACING_NW, FACING_NW, FACING_NE, FACING_E, FACING_E
-    };
-
-    /**
-     * Each port's 2 node coordinates on standard board.
-     * Same order as {@link #PORTS_FACING_V1}:
-     * Clockwise from upper-left (hex coordinate 0x17).
-     * @since 1.1.08
-     */
-    private final static int PORTS_EDGE_V1[] =
-    {
-        0x27,  // Port touches the upper-left land hex, port facing land to its SouthEast
-        0x5A,  // Touches middle land hex of top row, port facing SW
-        0x9C,  // Touches rightmost land hex of row above middle, SW
-        0xCC,  // Rightmost of middle-row land hex, W
-        0xC9,  // Rightmost land hex below middle, NW
-        0xA5,  // Port touches middle hex of bottom row, facing NW
-        0x72,  // Leftmost of bottom row, NE
-        0x42,  // Leftmost land hex of row below middle, E
-        0x24   // Leftmost land hex above middle, facing E
-    };
-
-    /**
-     * Each port's type, such as {@link #SHEEP_PORT}, on 6-player board.
-     * Same order as {@link #PORTS_FACING_V2}. {@link #MISC_PORT} is 0.
-     * @since 1.1.08
-     */
-    protected final static int PORTS_TYPE_V2[] =
-        { 0, 0, 0, 0, CLAY_PORT, ORE_PORT, SHEEP_PORT, WHEAT_PORT, WOOD_PORT, MISC_PORT, SHEEP_PORT };
-
-    /**
-     * Each port's <em>facing,</em> on 6-player board.
-     * Ordered clockwise from upper-left (hex coordinate 0x17, which is land in the V2 layout).
-     * Port Facing is the direction from the port hex/edge, to the land hex touching it
-     * which will have 2 nodes where a port settlement/city can be built.
-     * Within the board orientation (not the rotated visual orientation),
-     * facing 2 is east ({@link #FACING_E}), 3 is SE, 4 is SW, etc.
-     * @since 1.1.08
-     */
-    private final static int PORTS_FACING_V2[] =
-    {
-        FACING_SE, FACING_SW, FACING_SW, FACING_W, FACING_W, FACING_NW,
-        FACING_NW, FACING_NE, FACING_NE, FACING_E, FACING_SE
-    };
-
-    /**
-     * Each port's edge coordinate on the 6-player board.
-     * This is the edge whose 2 end nodes can be used to build port settlements/cities.
-     * Same order as {@link #PORTS_FACING_V2}:
-     * Clockwise from upper-left (hex coordinate 0x17, which is land in the V2 layout).
-     * @since 1.1.08
-     */
-    private final static int PORTS_EDGE_V2[] =
-    {
-        0x07,  // Port touches the upper-left land hex, port facing land to its SouthEast
-        0x3A,  // Touches middle land hex of top row, port facing SW
-        0x7C,  // Touches rightmost land hex of row below top, SW
-        0xAC,  // Touches rightmost land hex of row above middle, W
-        0xCA,  // Touches rightmost land hex of row below middle, W
-        0xC7,  // Touches rightmost land hex of row above bottom, NW
-        0xA3,  // Touches middle land hex of bottom row, NW
-        0x70,  // Touches bottom-left land hex, NE
-        0x30,  // Touches leftmost land hex of row below middle, NE
-        0x00,  // Leftmost hex of middle row, E
-        0x03   // Touches leftmost land hex of row above middle, SE
-    };
-
-    /**
-     * Board Encoding fields begin here
-     * ------------------------------------------------------------------------------------
-     */
-
     // If you add a new BOARD_ENCODING_* constant:
     // - Update MAX_BOARD_ENCODING
     // - Update the getBoardEncodingFormat javadocs
     // - Do where-used on the existing encoding constants and MAX_BOARD_ENCODING
     //   to look for other places you may need to check for the new constant
-
-    /**
-     * 4-player original format (v1) for {@link #getBoardEncodingFormat()}:
-     * Hexadecimal 0x00 to 0xFF along 2 diagonal axes.
-     * Coordinate range on each axis is 0 to 15 decimal. In hex:<pre>
-     *   Hexes: 11 to DD
-     *   Nodes: 01 or 10, to FE or EF
-     *   Edges: 00 to EE </pre>
-     *<P>
-     * See the Dissertation PDF for details.
-     * @since 1.1.06
-     */
-    public static final int BOARD_ENCODING_ORIGINAL = 1;
-
-    /**
-     * 6-player format (v2) for {@link #getBoardEncodingFormat()}:
-     * Land hexes are same encoding as {@link #BOARD_ENCODING_ORIGINAL}.
-     * Land starts 1 extra hex west of standard board,
-     * and has an extra row of land at north and south end.
-     *<P>
-     * Ports are not part of {@link #hexLayout} because their
-     * coordinates wouldn't fit within 2 hex digits.
-     * Instead, see {@link #getPortTypeFromNodeCoord(int)},
-     *   {@link #getPortsEdges()}, {@link #getPortsFacing()},
-     *   {@link #getPortCoordinates(int)} or {@link #getPortsLayout()}.
-     * @since 1.1.08
-     */
-    public static final int BOARD_ENCODING_6PLAYER = 2;
-
-    /**
-     * Sea board format (v3) used with {@link SOCBoardLarge} for {@link #getBoardEncodingFormat()}:
-     * Allows up to 127 x 127 board with an arbitrary mix of land and water tiles.
-     * Land, water, and port locations/facings are no longer hardcoded.
-     * Use {@link #getPortsCount()} to get the number of ports.
-     * For other port information, use the same methods as in {@link #BOARD_ENCODING_6PLAYER}.
-     *<P>
-     * Activated with {@link SOCGameOption} {@code "SBL"}.
-     * @since 2.0.00
-     */
-    public static final int BOARD_ENCODING_LARGE = 3;
-
-    /**
-     * Largest value of {@link #getBoardEncodingFormat()} supported in this version.
-     * @since 1.1.08
-     */
-    public static final int MAX_BOARD_ENCODING = 3;
 
     /**
      * Maximum valid coordinate value; size of board in coordinates (not in number of hexes across).
@@ -444,39 +292,10 @@ public class SOCBoard implements Serializable, Cloneable
     /**
      * Minimum and maximum edge and node coordinates in this board's encoding.
      * ({@link #MAXNODE} is the same in the v1 and v2 current encodings.)
-     * Not used in v3 ({@link #BOARD_ENCODING_LARGE}).
+     * Not used in v3 ({@link SOCBoardLarge#BOARD_ENCODING_LARGE}).
      * @since 1.1.08
      */
-    private int minNode, minEdge, maxEdge;
-
-    /**
-     * The encoding format of board coordinates,
-     * or {@link #BOARD_ENCODING_ORIGINAL} (default, original).
-     * The board size determines the required encoding format.
-     *<UL>
-     *<LI> 1 - Original format: hexadecimal 0x00 to 0xFF.
-     *       Coordinate range is 0 to 15 (in decimal).
-     *       Port types and facings encoded within {@link #hexLayout}.
-     *<LI> 2 - 6-player board, variant of original format: hexadecimal 0x00 to 0xFF.
-     *       Coordinate range is 0 to 15 (in decimal).
-     *       Port types stored in {@link #portsLayout}.
-     *       Added in 1.1.08.
-     *<LI> 3 - Large board ({@link #BOARD_ENCODING_LARGE}).
-     *       Coordinate range for rows,columns is each 0 to 255 decimal,
-     *       or altogether 0x0000 to 0xFFFF hex.
-     *       Arbitrary mix of land and water tiles.
-     *       Added in 2.0.00, implemented in {@link SOCBoardLarge}.
-     *       Activated with {@link SOCGameOption} <tt>"SBL"</tt>.
-     *</UL>
-     * Although this field is protected (not private), please treat it as read-only.
-     * @since 1.1.06
-     */
-    protected int boardEncodingFormat;
-
-    /**
-     * Board Encoding fields end here
-     * ------------------------------------------------------------------------------------
-     */
+    protected int minNode, minEdge, maxEdge;
 
     /**
      * largest coordinate value for a hex, in the current encoding.
@@ -489,75 +308,9 @@ public class SOCBoard implements Serializable, Cloneable
     protected static final int MINHEX = 0x11;
 
     /**
-     * largest coordinate value for an edge, in the v1 encoding.
-     * Named <tt>MAXEDGE</tt> before v1.1.11 ; the name change is a
-     * reminder that {@link #MAXEDGE_V2} represents a different encoding.
-     * @since 1.1.11
-     */
-    protected static final int MAXEDGE_V1 = 0xCC;
-
-    /**
-     * largest coordinate value for an edge, in the v2 encoding
-     * @since 1.1.08
-     */
-    protected static final int MAXEDGE_V2 = 0xCC;
-
-    /**
-     * smallest coordinate value for an edge, in the v1 encoding.
-     * Named <tt>MINEDGE</tt> before v1.1.11 ; the name change is a
-     * reminder that {@link #MINEDGE_V2} has a different value.
-     * @since 1.1.11
-     */
-    protected static final int MINEDGE_V1 = 0x22;
-
-    /**
-     * smallest coordinate value for an edge, in the v2 encoding
-     * @since 1.1.08
-     */
-    protected static final int MINEDGE_V2 = 0x00;
-
-    /**
      * largest coordinate value for a node on land, in the v1 and v2 encodings
      */
     private static final int MAXNODE = 0xDC;
-
-    /**
-     * smallest coordinate value for a node on land, in the v1 encoding.
-     * Named <tt>MINNODE</tt> before v1.1.11 ; the name change is a
-     * reminder that {@link #MINNODE_V2} has a different value.
-     * @since 1.1.11
-     */
-    protected static final int MINNODE_V1 = 0x23;
-
-    /**
-     * smallest coordinate value for a node on land, in the v2 encoding
-     * @since 1.1.08
-     */
-    protected static final int MINNODE_V2 = 0x01;
-
-    /**
-     * Land-hex coordinates in standard board ({@link #BOARD_ENCODING_ORIGINAL}).
-     * @since 1.1.08
-     */
-    public final static int[] HEXCOORDS_LAND_V1 =
-    {
-        0x33, 0x35, 0x37, 0x53, 0x55, 0x57, 0x59, 0x73, 0x75, 0x77, 0x79, 0x7B,
-        0x95, 0x97, 0x99, 0x9B, 0xB7, 0xB9, 0xBB
-    };
-
-    /**
-     * Land-hex coordinates in 6-player board ({@link #BOARD_ENCODING_6PLAYER}).
-     * @since 1.1.08.
-     */
-    public final static int[] HEXCOORDS_LAND_V2 =
-    {
-        0x11, 0x13, 0x15, 0x17,      // First diagonal row (moving NE from 0x11)
-        0x31, 0x33, 0x35, 0x37, 0x39,
-        0x51, 0x53, 0x55, 0x57, 0x59, 0x5B,
-        0x71, 0x73, 0x75, 0x77, 0x79, 0x7B,
-        0x93, 0x95, 0x97, 0x99, 0x9B,
-        0xB5, 0xB7, 0xB9, 0xBB       // Last diagonal row (NE from 0xB5)
-    };
 
     /***************************************
      * Hex data array, one element per water or land (or port, which is special water) hex.
@@ -569,9 +322,9 @@ public class SOCBoard implements Serializable, Cloneable
      *<P>
      * <b>Key to the hexLayout[] values:</b>
      *<br>
-     * Note that hexLayout contains ports only for the v1 encoding ({@link #BOARD_ENCODING_ORIGINAL});
+     * Note that hexLayout contains ports only for the v1 encoding ({@link Standard4p#BOARD_ENCODING_ORIGINAL});
      * v2 and v3 use {@link #portsLayout} instead, and hexLayout contains only water and the land
-     * hex types.  The v3 encoding ({@link #BOARD_ENCODING_LARGE}) doesn't use {@code hexLayout} at all,
+     * hex types.  The v3 encoding ({@link SOCBoardLarge#BOARD_ENCODING_LARGE}) doesn't use {@code hexLayout} at all,
      * instead it has a 2-dimensional {@code hexLayoutLg} structure.
        <pre>
        0 : water   {@link #WATER_HEX} (was 6 before v2.0.00)
@@ -613,8 +366,8 @@ public class SOCBoard implements Serializable, Cloneable
             /\/\
       4 &lt;--.    .--> 3  </pre>
      *<P>
-     *  For board encoding formats {@link #BOARD_ENCODING_ORIGINAL} and
-     *  {@link #BOARD_ENCODING_6PLAYER}, hexLayout indexes are arranged
+     *  For board encoding formats {@link Standard4p#BOARD_ENCODING_ORIGINAL} and
+     *  {@link Standard6p#BOARD_ENCODING_6PLAYER}, hexLayout indexes are arranged
      *  this way per {@link #numToHexID}: <pre>
        0   1   2   3
 
@@ -658,9 +411,9 @@ public class SOCBoard implements Serializable, Cloneable
      *
      *<LI> v2: On the 6-player (v2 layout) board, each port's type.
      * Same value range as in {@link #hexLayout}.
-     * 1 element per port. Same ordering as {@link #PORTS_FACING_V2}.
+     * 1 element per port. Same ordering as {@link Standard6p#PORTS_FACING_V2}.
      *
-     *<LI> v3: {@link #BOARD_ENCODING_LARGE} stores more information
+     *<LI> v3: {@link SOCBoardLarge#BOARD_ENCODING_LARGE} stores more information
      * within the port layout array.  <em>n</em> = {@link #getPortsCount()}.
      * The port types are stored at the beginning, from index 0 to <em>n</em> - 1.
      * The next <em>n</em> indexes store each port's edge coordinate.
@@ -691,7 +444,7 @@ public class SOCBoard implements Serializable, Cloneable
      *  The robber hex is 0.  Water hexes are -1.
      *<P>
      *  Used in the v1 and v2 encodings (ORIGINAL, 6PLAYER).
-     *  The v3 encoding ({@link #BOARD_ENCODING_LARGE}) doesn't use this array,
+     *  The v3 encoding ({@link SOCBoardLarge#BOARD_ENCODING_LARGE}) doesn't use this array,
      *  instead it uses {@link SOCBoardLarge#numberLayoutLg}.
      */
     private int[] numberLayout =
@@ -704,36 +457,30 @@ public class SOCBoard implements Serializable, Cloneable
     /** Hex coordinates ("IDs") of each hex number ("hex number" means index within
      *  {@link #hexLayout}).
      *<UL>
-     *<LI> {@link #BOARD_ENCODING_ORIGINAL}:  The hexes in here are the board's land hexes and also
+     *<LI> {@link Standard4p#BOARD_ENCODING_ORIGINAL}:  The hexes in here are the board's land hexes and also
      *     the surrounding ring of water/port hexes.
-     *<LI> {@link #BOARD_ENCODING_6PLAYER}:  The hexes in here are the board's land hexes and also
+     *<LI> {@link Standard6p#BOARD_ENCODING_6PLAYER}:  The hexes in here are the board's land hexes and also
      *     the unused hexes (rightmost column: 7D - DD - D7).
-     *<LI> {@link #BOARD_ENCODING_LARGE}: Does not use numToHexID or hexLayout; hex coordinate == hex number.
+     *<LI> {@link SOCBoardLarge#BOARD_ENCODING_LARGE}: Does not use numToHexID or hexLayout; hex coordinate == hex number.
      *</UL>
+     *
+     * See also: RST's dissertation figure A.1.
+     *
      * @see #hexIDtoNum
      * @see #nodesOnLand
-     * @see #HEXCOORDS_LAND_V1
-     * @see #HEXCOORDS_LAND_V2
+     * @see Standard4p#HEXCOORDS_LAND_V1
+     * @see Standard6p#HEXCOORDS_LAND_V2
      * @see #getLandHexCoords()
      */
     private int[] numToHexID =
     {
         0x17, 0x39, 0x5B, 0x7D,
-
         0x15, 0x37, 0x59, 0x7B, 0x9D,
-
         0x13, 0x35, 0x57, 0x79, 0x9B, 0xBD,
-
         0x11, 0x33, 0x55, 0x77, 0x99, 0xBB, 0xDD,
-
         0x31, 0x53, 0x75, 0x97, 0xB9, 0xDB,
-
         0x51, 0x73, 0x95, 0xB7, 0xD9,
-
         0x71, 0x93, 0xB5, 0xD7
-
-        // The hex coordinate layout given here can also
-        // be seen in RST's dissertation figure A.1.
     };
 
     /**
@@ -769,7 +516,7 @@ public class SOCBoard implements Serializable, Cloneable
      */
     private final static int[] HEXNODES = { 0x01, 0x12, 0x21, 0x10, -0x01, -0x10 };
 
-    /**
+    /*
      * offset of all hexes adjacent to a node
      * -- @see #getAdjacentHexesToNode(int) instead
      * private int[] nodeToHex = { -0x21, 0x01, -0x01, -0x10, 0x10, -0x12 };
@@ -789,14 +536,14 @@ public class SOCBoard implements Serializable, Cloneable
      * the hex coordinate that the robber is in, or -1; placed on desert in {@link #makeNewBoard(Map)}.
      * Once the robber is placed on the board, it cannot be removed (cannot become -1 again).
      */
-    private int robberHex;
+    private int robberHex = -1;  // Soon placed on desert, when makeNewBoard is called;
 
     /**
      * the previous hex coordinate that the robber is in; -1 unless
      * {@link #setRobberHex(int, boolean) setRobberHex(rh, true)} was called.
      * @since 1.1.11
      */
-    private int prevRobberHex;
+    private int prevRobberHex = -1;
 
     /**
      * Maximum hex type value for the robber; can be used for array sizing.
@@ -804,7 +551,7 @@ public class SOCBoard implements Serializable, Cloneable
      * @see SOCGame#canMoveRobber(int, int)
      * @since 2.0.00
      */
-    public final int max_robber_hextype;
+    public final int max_robber_hextype = MAX_LAND_HEX;
 
     /**
      * where the ports of each type are; coordinates per port type.
@@ -815,24 +562,18 @@ public class SOCBoard implements Serializable, Cloneable
      * @see #portsLayout
      * @see #getPortsEdges()
      */
-    protected Vector<Integer>[] ports;
+    protected Vector<Integer>[] ports = new Vector[6];  // 1 per resource type, MISC_PORT to WOOD_PORT;
 
     /**
      * roads on the board; Vector of SOCPlayingPiece.
      * On the large sea board ({@link SOCBoardLarge}), also
      * contains all ships on the board.
+     * TODO: add Vector of Ship
      */
-    protected Vector<SOCRoad> roads;
+    protected Vector<SOCRoad> roads = new Vector<>(60);
 
-    /**
-     * settlements on the board; Vector of SOCPlayingPiece
-     */
-    protected Vector<SOCSettlement> settlements;
-
-    /**
-     * cities on the board; Vector of SOCPlayingPiece
-     */
-    protected Vector<SOCCity> cities;
+    protected Vector<SOCSettlement> settlements = new Vector<>(20);
+    protected Vector<SOCCity> cities = new Vector<>(16);
 
     /**
      * random number generator
@@ -851,54 +592,26 @@ public class SOCBoard implements Serializable, Cloneable
      * (groups of islands), if {@link SOCBoardLarge#getLandAreasLegalNodes()} != null.
      * In that case, <tt>nodesOnLand</tt> contains all nodes of all land areas.
      */
-    protected HashSet<Integer> nodesOnLand;
+    protected HashSet<Integer> nodesOnLand = new HashSet<>();
 
     /**
      * Minimal super constructor for subclasses.
-     * Sets {@link #boardEncodingFormat}, {@link #robberHex}, {@link #prevRobberHex}.
-     * Creates empty Vectors for {@link #roads}, {@link #settlements},
-     *   {@link #cities} and {@link #ports}, but not {@link #portsLayout}.
-     * Creates an empty HashSet for {@link #nodesOnLand}.
      *<P>
      * Most likely you should also call {@link #setBoardBounds(int, int)}.
      *
-     * @param boardEncodingFmt  A format constant in the currently valid range:
-     *         Must be >= {@link #BOARD_ENCODING_ORIGINAL} and &lt;= {@link #MAX_BOARD_ENCODING}.
-     * @param maxRobberHextype  Maximum land hextype value, or maximum hex type
-     *         the robber can be placed at.  Same value range as {@link #max_robber_hextype}
-     *         and as your subclass's {@link #getHexTypeFromCoord(int)} method.
      * @since 2.0.00
      * @throws IllegalArgumentException if <tt>boardEncodingFmt</tt> is out of range
      */
     @SuppressWarnings("unchecked")
-    protected SOCBoard(final int boardEncodingFmt, final int maxRobberHextype)
-        throws IllegalArgumentException
+    protected SOCBoard()
     {
-        if ((boardEncodingFmt < 1) || (boardEncodingFmt > MAX_BOARD_ENCODING))
-            throw new IllegalArgumentException(Integer.toString(boardEncodingFmt));
+        initializePorts();
+    }
 
-        boardEncodingFormat = boardEncodingFmt;
-
-        robberHex = -1;  // Soon placed on desert, when makeNewBoard is called
-        prevRobberHex = -1;
-        max_robber_hextype = maxRobberHextype;
-
-        nodesOnLand = new HashSet<Integer>();
-
-        /**
-         * initialize the pieces vectors
-         */
-        roads = new Vector<SOCRoad>(60);
-        settlements = new Vector<SOCSettlement>(20);
-        cities = new Vector<SOCCity>(16);
-
-        /**
-         * initialize the port vector
-         */
-        ports = new Vector[6];  // 1 per resource type, MISC_PORT to WOOD_PORT
-        ports[MISC_PORT] = new Vector<Integer>(8);
+    protected void initializePorts() {
+        ports[MISC_PORT] = new Vector<>(8);
         for (int i = CLAY_PORT; i <= WOOD_PORT; i++)
-            ports[i] = new Vector<Integer>(2);
+            ports[i] = new Vector<>(2);
     }
 
     /**
@@ -909,42 +622,20 @@ public class SOCBoard implements Serializable, Cloneable
      * @throws IllegalArgumentException if <tt>maxPlayers</tt> is not 4 or 6
      * @see BoardFactory#createBoard(Map, boolean, int)
      */
-    protected SOCBoard(Map<String,SOCGameOption> gameOpts, final int maxPlayers)
+    protected SOCBoard(Map<String, SOCGameOption> gameOpts, final int maxPlayers)
         throws IllegalArgumentException
     {
-        // set boardEncodingFormat, robberHex, prevRobberHex,
-        //  and create empty vectors for pieces & port node coordinates:
-        this( (maxPlayers == 6) ? BOARD_ENCODING_6PLAYER : BOARD_ENCODING_ORIGINAL, MAX_LAND_HEX );
+        initializePorts();
 
-        if ((maxPlayers != 4) && (maxPlayers != 6))
+        if (maxPlayers != 4 && maxPlayers != 6)
             throw new IllegalArgumentException("maxPlayers: " + maxPlayers);
 
         boardWidth = 0x10;
         boardHeight = 0x10;
-        final boolean is6player = (maxPlayers == 6);
 
-        if (is6player)
-        {
-            // boardEncodingFormat = BOARD_ENCODING_6PLAYER;
-            minEdge = MINEDGE_V2;
-            maxEdge = MAXEDGE_V2;
-            minNode = MINNODE_V2;
-        } else {
-            // boardEncodingFormat = BOARD_ENCODING_ORIGINAL;  // See javadoc of boardEncodingFormat
-            minEdge = MINEDGE_V1;
-            maxEdge = MAXEDGE_V1;
-            minNode = MINNODE_V1;
-        }
-
-        /**
-         * generic counter
-         */
+        // initialize the hexIDtoNum array
+        // See dissertation figure A.1 for coordinates
         int i;
-
-        /**
-         * initialize the hexIDtoNum array;
-         * see dissertation figure A.1 for coordinates
-         */
         hexIDtoNum = new int[0xEE];  // Length must be >= MAXHEX
 
         for (i = 0; i < 0xEE; i++)
@@ -966,18 +657,17 @@ public class SOCBoard implements Serializable, Cloneable
     }
 
     /**
-     * As part of the constructor, check the {@link #boardEncodingFormat}
      * and initialize {@link #nodesOnLand} accordingly.
      * @see #initPlayerLegalAndPotentialSettlements()
      * @since 2.0.00
      */
     private void initNodesOnLand()
     {
-        final boolean is6player = (boardEncodingFormat == BOARD_ENCODING_6PLAYER);
+        final boolean is6player = getBoardEncodingFormat() == Standard6p.BOARD_ENCODING_6PLAYER;
 
-        nodesOnLand = new HashSet<Integer>();
+        nodesOnLand = new HashSet<>();
 
-        /**
+        /*
          * initialize the list of nodes on the land of the board;
          * nodes on outer edges of surrounding water/ports are not on the board.
          * See dissertation figure A.2.
@@ -993,31 +683,31 @@ public class SOCBoard implements Serializable, Cloneable
         if (is6player)
         {
             for (i = 0x07; i <= 0x6D; i += 0x11)
-                nodesOnLand.add(new Integer(i));
+                nodesOnLand.add(i);
         }
 
         for (i = 0x27 - westAdj; i <= 0x8D; i += 0x11)  //  Northernmost horizontal row: each north corner across 3 hexes
-            nodesOnLand.add(new Integer(i));
+            nodesOnLand.add(i);
 
         for (i = 0x25 - westAdj; i <= 0xAD; i += 0x11)  // Next: each north corner of row of 4 / south corner of the northernmost 3 hexes
-            nodesOnLand.add(new Integer(i));
+            nodesOnLand.add(i);
 
         for (i = 0x23 - westAdj; i <= 0xCD; i += 0x11)  // Next: north corners of middle row of 5 hexes
-            nodesOnLand.add(new Integer(i));
+            nodesOnLand.add(i);
 
         for (i = 0x32 - westAdj; i <= 0xDC; i += 0x11) // Next: south corners of middle row of 5 hexes
-            nodesOnLand.add(new Integer(i));
+            nodesOnLand.add(i);
 
         for (i = 0x52 - westAdj; i <= 0xDA; i += 0x11)  // South corners of row of 4 / north corners of the southernmost 3 hexes
-            nodesOnLand.add(new Integer(i));
+            nodesOnLand.add(i);
 
         for (i = 0x72 - westAdj; i <= 0xD8; i += 0x11)  // Southernmost horizontal row: each south corner across 3 hexes
-            nodesOnLand.add(new Integer(i));
+            nodesOnLand.add(i);
 
         if (is6player)
         {
             for (i = 0x70; i <= 0xD6; i += 0x11)
-                nodesOnLand.add(new Integer(i));
+                nodesOnLand.add(i);
         }
     }
 
@@ -1030,7 +720,7 @@ public class SOCBoard implements Serializable, Cloneable
      * @param num   Number to assign to first {@link #hexIDtoNum}[] within this coordinate range;
      *              corresponds to hex's index ("hex number") within {@link #hexLayout}.
      */
-    private final void initHexIDtoNumAux(int begin, int end, int num)
+    private void initHexIDtoNumAux(int begin, int end, int num)
     {
         int i;
 
@@ -1040,146 +730,6 @@ public class SOCBoard implements Serializable, Cloneable
             num++;
         }
     }
-
-    /**
-     * Possible number paths for 4-player original board.
-     * {@link #makeNewBoard(Map)} randomly chooses one path (one 1-dimensional array)
-     * to be used as <tt>numPath[]</tt> in
-     * {@link #makeNewBoard_placeHexes(int[], int[], int[], SOCGameOption)}.
-     */
-    private final static int[][] makeNewBoard_numPaths_v1 =
-    {
-        // Numbers are indexes within hexLayout (also in numberLayout) for each land hex.
-        // See the hexLayout javadoc for how the indexes are arranged on the board layout.
-
-        // counterclockwise from southwest
-        {
-            29, 30, 31, 26, 20, 13, 7, 6, 5, 10, 16, 23,  // outermost hexes
-            24, 25, 19, 12, 11, 17,    18  // middle ring, center hex
-        },
-
-        // clockwise from southwest
-        {
-            29, 23, 16, 10, 5, 6, 7, 13, 20, 26, 31, 30,
-            24, 17, 11, 12, 19, 25,    18
-        },
-
-        // counterclockwise from east corner
-        {
-            20, 13, 7, 6, 5, 10, 16, 23, 29, 30, 31, 26,
-            19, 12, 11, 17, 24, 25,    18
-        },
-
-        // clockwise from east corner
-        {
-            20, 26, 31, 30, 29, 23, 16, 10, 5, 6, 7, 13,
-            19, 25, 24, 17, 11, 12,    18
-        },
-
-        // counterclockwise from northwest
-        {
-            5, 10, 16, 23, 29, 30, 31, 26, 20, 13, 7, 6,
-            11, 17, 24, 25, 19, 12,    18
-        },
-
-        // clockwise from northwest
-        {
-            5, 6, 7, 13, 20, 26, 31, 30, 29, 23, 16, 10,
-            11, 12, 19, 25, 24, 17,    18
-        }
-    };
-
-    /**
-     * Possible number paths for 6-player board.
-     * {@link #makeNewBoard(Map)} randomly chooses one path (one 1-dimensional array)
-     * to be used as <tt>numPath[]</tt> in
-     * {@link #makeNewBoard_placeHexes(int[], int[], int[], SOCGameOption)}.
-     */
-    private final static int[][] makeNewBoard_numPaths_v2 =
-    {
-        // Numbers are indexes within hexLayout (also in numberLayout) for each land hex.
-        // See the hexLayout javadoc for how the indexes are arranged on the board layout,
-        // and remember that the 6-player board is visually rotated clockwise 90 degrees;
-        // visual "North" used here is West internally in the board layout.
-
-        // clockwise from north
-        {
-            15, 9, 4, 0, 1, 2, 7, 13, 20, 26, 31, 35, 34, 33, 28, 22,  // outermost hexes
-            16, 10, 5, 6, 12, 19, 25, 30, 29, 23,  // middle ring of hexes
-            17, 11, 18, 24                         // center hexes
-        },
-
-        // counterclockwise from north
-        {
-            15, 22, 28, 33, 34, 35, 31, 26, 20, 13, 7, 2, 1, 0, 4, 9,
-            16, 23, 29, 30, 25, 19, 12, 6, 5, 10,
-            17, 24, 18, 11
-        },
-
-        // clockwise from south
-        {
-            20, 26, 31, 35, 34, 33, 28, 22, 15, 9, 4, 0, 1, 2, 7, 13,
-            19, 25, 30, 29, 23, 16, 10, 5, 6, 12,
-            18, 24, 17, 11
-        },
-
-        // counterclockwise from south
-        {
-            20, 13, 7, 2, 1, 0, 4, 9, 15, 22, 28, 33, 34, 35, 31, 26,
-            19, 12, 6, 5, 10, 16, 23, 29, 30, 25,
-            18, 11, 17, 24
-        }
-    };
-
-    /**
-     * Land hex types on the original 4-player board layout (v1).
-     * For more information see {@link #makeNewBoard_placeHexes(int[], int[], int[], SOCGameOption)}.
-     * @since 2.0.00
-     */
-    protected static final int[] makeNewBoard_landHexTypes_v1 =
-        { DESERT_HEX, CLAY_HEX, CLAY_HEX, CLAY_HEX,
-            ORE_HEX, ORE_HEX, ORE_HEX,
-            SHEEP_HEX, SHEEP_HEX, SHEEP_HEX, SHEEP_HEX,
-            WHEAT_HEX, WHEAT_HEX, WHEAT_HEX, WHEAT_HEX,
-            WOOD_HEX, WOOD_HEX, WOOD_HEX, WOOD_HEX };
-
-    /**
-     * Dice numbers in the original 4-player board layout, in order along {@code numPath} ({@link #makeNewBoard_numPaths_v1}).
-     * For more information see {@link #makeNewBoard_placeHexes(int[], int[], int[], SOCGameOption)}.
-     * @since 2.0.00
-     */
-    protected static final int[] makeNewBoard_diceNums_v1 =
-        { 5, 2, 6, 3, 8, 10, 9, 12, 11, 4, 8, 10, 9, 4, 5, 6, 3, 11 };
-
-    /**
-     * Land hex types on the 6-player board layout (v2).
-     * For more information see {@link #makeNewBoard_placeHexes(int[], int[], int[], SOCGameOption)}.
-     * @since 2.0.00
-     */
-    protected static final int[] makeNewBoard_landHexTypes_v2 =
-        {
-            DESERT_HEX, CLAY_HEX, CLAY_HEX, CLAY_HEX, ORE_HEX, ORE_HEX, ORE_HEX,
-            SHEEP_HEX, SHEEP_HEX, SHEEP_HEX, SHEEP_HEX,
-            WHEAT_HEX, WHEAT_HEX, WHEAT_HEX, WHEAT_HEX,
-            WOOD_HEX, WOOD_HEX, WOOD_HEX, WOOD_HEX,   // last line of v1's hexes
-            DESERT_HEX, CLAY_HEX, CLAY_HEX, ORE_HEX, ORE_HEX, SHEEP_HEX, SHEEP_HEX,
-            WHEAT_HEX, WHEAT_HEX, WOOD_HEX, WOOD_HEX
-        };
-
-    /**
-     * Dice numbers in the 6-player board layout, in order along {@code numPath} ({@link #makeNewBoard_numPaths_v2}).
-     * For more information see {@link #makeNewBoard_placeHexes(int[], int[], int[], SOCGameOption)}.
-     * @since 2.0.00
-     */
-    protected static final int[] makeNewBoard_diceNums_v2 =
-        {
-            2,   5,  4,  6 , 3, // A-E
-            9,   8, 11, 11, 10, // F-J
-            6,   3,  8,  4,  8, // K-O
-            10, 11, 12, 10,  5, // P-T
-            4,   9,  5,  9, 12, // U-Y
-            3,   2,  6          // Za-Zc
-        };
 
     /**
      * Shuffle the hex tiles and layout a board.
@@ -1193,7 +743,7 @@ public class SOCBoard implements Serializable, Cloneable
      */
     public void makeNewBoard(final Map<String, SOCGameOption> opts)
     {
-        final boolean is6player = (boardEncodingFormat == BOARD_ENCODING_6PLAYER);
+        final boolean is6player = getBoardEncodingFormat() == Standard6p.BOARD_ENCODING_6PLAYER;
 
         final SOCGameOption opt_breakClumps = (opts != null ? opts.get("BC") : null);
 
@@ -1201,15 +751,15 @@ public class SOCBoard implements Serializable, Cloneable
         // sets robberHex, contents of hexLayout[] and numberLayout[].
         // Also checks vs game option BC: Break up clumps of # or more same-type hexes/ports
         {
-            final int[] landHex = is6player ? makeNewBoard_landHexTypes_v2 : makeNewBoard_landHexTypes_v1;
-            final int[][] numPaths = is6player ? makeNewBoard_numPaths_v2 : makeNewBoard_numPaths_v1;
+            final int[] landHex = is6player ? Standard6p.makeNewBoard_landHexTypes_v2 : Standard4p.makeNewBoard_landHexTypes_v1;
+            final int[][] numPaths = is6player ? Standard6p.makeNewBoard_numPaths_v2 : Standard4p.makeNewBoard_numPaths_v1;
             final int[] numPath = numPaths[ Math.abs(rand.nextInt() % numPaths.length) ];
-            final int[] numbers = is6player ? makeNewBoard_diceNums_v2 : makeNewBoard_diceNums_v1;
+            final int[] numbers = is6player ? Standard6p.makeNewBoard_diceNums_v2 : Standard4p.makeNewBoard_diceNums_v1;
             makeNewBoard_placeHexes(landHex, numPath, numbers, opt_breakClumps);
         }
 
         // copy and shuffle the ports, and check vs game option BC
-        final int[] portTypes = (is6player) ? PORTS_TYPE_V2 : PORTS_TYPE_V1;
+        final int[] portTypes = (is6player) ? Standard6p.PORTS_TYPE_V2 : Standard4p.PORTS_TYPE_V1;
         int[] portHex = new int[portTypes.length];
         System.arraycopy(portTypes, 0, portHex, 0, portTypes.length);
         makeNewBoard_shufflePorts(portHex, opt_breakClumps);
@@ -1218,21 +768,21 @@ public class SOCBoard implements Serializable, Cloneable
 
         // place the ports (hex numbers and facing) within hexLayout and nodeIDtoPortType.
         // fill out the ports[] vectors with node coordinates where a trade port can be placed.
-        nodeIDtoPortType = new HashMap<Integer,Integer>();
+        nodeIDtoPortType = new HashMap<>();
         if (is6player)
         {
-            for (int i = 0; i < PORTS_FACING_V2.length; ++i)
+            for (int i = 0; i < Standard6p.PORTS_FACING_V2.length; ++i)
             {
                 final int ptype = portHex[i];
-                final int[] nodes = getAdjacentNodesToEdge_arr(PORTS_EDGE_V2[i]);
-                placePort(ptype, -1, PORTS_FACING_V2[i], nodes[0], nodes[1]);
+                final int[] nodes = getAdjacentNodesToEdge_arr(Standard6p.PORTS_EDGE_V2[i]);
+                placePort(ptype, -1, Standard6p.PORTS_FACING_V2[i], nodes[0], nodes[1]);
             }
         } else {
-            for (int i = 0; i < PORTS_FACING_V1.length; ++i)
+            for (int i = 0; i < Standard4p.PORTS_FACING_V1.length; ++i)
             {
                 final int ptype = portHex[i];
-                final int[] nodes = getAdjacentNodesToEdge_arr(PORTS_EDGE_V1[i]);
-                placePort(ptype, PORTS_HEXNUM_V1[i], PORTS_FACING_V1[i], nodes[0], nodes[1]);
+                final int[] nodes = getAdjacentNodesToEdge_arr(Standard4p.PORTS_EDGE_V1[i]);
+                placePort(ptype, Standard4p.PORTS_HEXNUM_V1[i], Standard4p.PORTS_FACING_V1[i], nodes[0], nodes[1]);
             }
         }
 
@@ -1260,7 +810,7 @@ public class SOCBoard implements Serializable, Cloneable
      * @throws IllegalArgumentException if {@link #makeNewBoard_checkLandHexResourceClumps(Vector, int)}
      *                 finds an invalid or uninitialized hex coordinate (hex type -1)
      */
-    private final void makeNewBoard_placeHexes
+    private void makeNewBoard_placeHexes
         (int[] landHex, final int[] numPath, final int[] number, SOCGameOption optBC)
         throws IllegalArgumentException
     {
@@ -1308,10 +858,10 @@ public class SOCBoard implements Serializable, Cloneable
 
             if (checkClumps)
             {
-                Vector<Integer> unvisited = new Vector<Integer>();  // contains each land hex's coordinate
+                Vector<Integer> unvisited = new Vector<>();  // contains each land hex's coordinate
                 for (int i = 0; i < landHex.length; ++i)
                 {
-                    unvisited.addElement(new Integer(numToHexID[numPath[i]]));
+                    unvisited.addElement(numToHexID[numPath[i]]);
                 }
                 clumpsNotOK = makeNewBoard_checkLandHexResourceClumps(unvisited, clumpSize);
             }  // if (checkClumps)
@@ -1354,7 +904,7 @@ public class SOCBoard implements Serializable, Cloneable
         if (clumpSize < 3)
             return false;
 
-        /**
+        /*
          * Depth-first search to check land hexes for resource clumps.
          *
          * Start with the set of all land hexes, and consider them 'unvisited'.
@@ -1419,7 +969,7 @@ public class SOCBoard implements Serializable, Cloneable
 
             //     - remove this from unvisited-set
             Integer hexCoordObj = unvisited.elementAt(0);
-            final int hexCoord = hexCoordObj.intValue();
+            final int hexCoord = hexCoordObj;
             final int resource = getHexTypeFromCoord(hexCoord);
             unvisited.removeElementAt(0);
             if (resource == -1)  // would cause inf loop, this "clump" can't be broken up
@@ -1445,12 +995,12 @@ public class SOCBoard implements Serializable, Cloneable
             for (int i = 0; i < adjacent.size(); ++i)
             {
                 Integer adjCoordObj = adjacent.elementAt(i);
-                final int adjCoord = adjCoordObj.intValue();
+                final int adjCoord = adjCoordObj;
                 if (resource == getHexTypeFromCoord(adjCoord))
                 {
                     // keep this one
                     if (clump == null)
-                        clump = new Vector<Integer>();
+                        clump = new Vector<>();
                     clump.addElement(adjCoordObj);
                     unvisited.remove(adjCoordObj);
                 }
@@ -1465,8 +1015,7 @@ public class SOCBoard implements Serializable, Cloneable
             for (int ic = 1; ic < clump.size(); )  // ++ic is within loop body, if nothing inserted
             {
                 // precondition: each hex already in clump set, is not in unvisited-vec
-                Integer chexCoordObj = clump.elementAt(ic);
-                final int chexCoord = chexCoordObj.intValue();
+                final int chexCoord = clump.elementAt(ic);
 
                 //  - look at its adjacent unvisited hexes of same type
                 //  - if none, done looking at this hex
@@ -1484,7 +1033,7 @@ public class SOCBoard implements Serializable, Cloneable
                 for (int ia = 0; ia < adjacent2.size(); ++ia)
                 {
                     Integer adjCoordObj = adjacent2.elementAt(ia);
-                    final int adjCoord = adjCoordObj.intValue();
+                    final int adjCoord = adjCoordObj;
                     if ((resource == getHexTypeFromCoord(adjCoord))
                         && unvisited.contains(adjCoordObj))
                     {
@@ -1612,7 +1161,7 @@ public class SOCBoard implements Serializable, Cloneable
      * Adds the 2 nodes to {@link #ports}<tt>[ptype]</tt>.
      * @param ptype Port type; in range {@link #MISC_PORT} to {@link #WOOD_PORT}.
      * @param hex  Hex number (index) within {@link #hexLayout}, or -1 if
-     *           {@link #BOARD_ENCODING_6PLAYER} or if you don't want to change
+     *           {@link Standard6p#BOARD_ENCODING_6PLAYER} or if you don't want to change
      *           <tt>hexLayout[hex]</tt>'s value.
      * @param face Facing of port towards land; 1 to 6 ({@link #FACING_NE} to {@link #FACING_NW}).
      *           Ignored if <tt>hex == -1</tt>.
@@ -1634,9 +1183,9 @@ public class SOCBoard implements Serializable, Cloneable
             }
         }
 
-        final Integer node1Int = new Integer(node1),
-                      node2Int = new Integer(node2),
-                      ptypeInt = new Integer(ptype);
+        final Integer node1Int = node1,
+                      node2Int = node2,
+                      ptypeInt = ptype;
 
         nodeIDtoPortType.put(node1Int, ptypeInt);
         nodeIDtoPortType.put(node2Int, ptypeInt);
@@ -1660,15 +1209,15 @@ public class SOCBoard implements Serializable, Cloneable
      * @return the set of legal edge coordinates for roads, as a new Set of {@link Integer}s
      * @since 1.1.12
      */
-    HashSet<Integer> initPlayerLegalRoads()
+    public HashSet<Integer> initPlayerLegalRoads()
     {
         // 6-player starts land 1 extra hex (2 edges) west of standard board,
         // and has an extra row of land hexes at north and south end.
         final boolean is6player =
-            (boardEncodingFormat == BOARD_ENCODING_6PLAYER);
+                getBoardEncodingFormat() == Standard6p.BOARD_ENCODING_6PLAYER;
         final int westAdj = (is6player) ? 0x22 : 0x00;
 
-        HashSet<Integer> legalRoads = new HashSet<Integer>(97);  // 4-pl board 72 roads; load factor 0.75
+        HashSet<Integer> legalRoads = new HashSet<>(97);  // 4-pl board 72 roads; load factor 0.75
 
         // Set each row of valid road (edge) coordinates:
         int i;
@@ -1676,52 +1225,52 @@ public class SOCBoard implements Serializable, Cloneable
         if (is6player)
         {
             for (i = 0x07; i <= 0x5C; i += 0x11)
-                legalRoads.add(new Integer(i));
+                legalRoads.add(i);
 
             for (i = 0x06; i <= 0x6C; i += 0x22)
-                legalRoads.add(new Integer(i));
+                legalRoads.add(i);
         }
 
         for (i = 0x27 - westAdj; i <= 0x7C; i += 0x11)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(i);
 
         for (i = 0x26 - westAdj; i <= 0x8C; i += 0x22)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(i);
 
         for (i = 0x25 - westAdj; i <= 0x9C; i += 0x11)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(i);
 
         for (i = 0x24 - westAdj; i <= 0xAC; i += 0x22)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(i);
 
         for (i = 0x23 - westAdj; i <= 0xBC; i += 0x11)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(i);
 
         for (i = 0x22 - westAdj; i <= 0xCC; i += 0x22)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(i);
 
         for (i = 0x32 - westAdj; i <= 0xCB; i += 0x11)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(i);
 
         for (i = 0x42 - westAdj; i <= 0xCA; i += 0x22)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(i);
 
         for (i = 0x52 - westAdj; i <= 0xC9; i += 0x11)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(i);
 
         for (i = 0x62 - westAdj; i <= 0xC8; i += 0x22)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(i);
 
         for (i = 0x72 - westAdj; i <= 0xC7; i += 0x11)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(i);
 
         if (is6player)
         {
             for (i = 0x60; i <= 0xC6; i += 0x22)
-                legalRoads.add(new Integer(i));
+                legalRoads.add(i);
 
             for (i = 0x70; i <= 0xC5; i += 0x11)
-                legalRoads.add(new Integer(i));
+                legalRoads.add(i);
         }
 
         return legalRoads;
@@ -1743,9 +1292,9 @@ public class SOCBoard implements Serializable, Cloneable
      * @since 1.1.12
      * @see #nodesOnLand
      */
-    HashSet<Integer> initPlayerLegalAndPotentialSettlements()
+    public HashSet<Integer> initPlayerLegalAndPotentialSettlements()
     {
-        HashSet<Integer> legalSettlements = new HashSet<Integer>(nodesOnLand);
+        HashSet<Integer> legalSettlements = new HashSet<>(nodesOnLand);
         return legalSettlements;
     }
 
@@ -1754,7 +1303,7 @@ public class SOCBoard implements Serializable, Cloneable
      *     Please treat the returned array as read-only.
      * @see #getLandHexCoords()
      * @throws UnsupportedOperationException if the board encoding doesn't support this method;
-     *     the v1 and v2 encodings do, but v3 ({@link #BOARD_ENCODING_LARGE}) does not.
+     *     the v1 and v2 encodings do, but v3 ({@link SOCBoardLarge#BOARD_ENCODING_LARGE}) does not.
      */
     public int[] getHexLayout()
         throws UnsupportedOperationException
@@ -1772,14 +1321,7 @@ public class SOCBoard implements Serializable, Cloneable
      */
     public int[] getLandHexCoords()
     {
-        switch (boardEncodingFormat)
-        {
-        case BOARD_ENCODING_6PLAYER:
-            return HEXCOORDS_LAND_V2;
-        default:
-            return HEXCOORDS_LAND_V1;
-        }
-        // BOARD_ENCODING_LARGE (v3) overrides this in SOCBoardLarge.
+        throw new UnsupportedOperationException(); // implemented in derived classes
     }
 
     /**
@@ -1816,12 +1358,12 @@ public class SOCBoard implements Serializable, Cloneable
 
     /**
      * The dice-number layout of dice rolls at each hex number.
-     * Valid for the v1 and v2 encodings, not v3 ({@link #BOARD_ENCODING_LARGE}).
+     * Valid for the v1 and v2 encodings, not v3 ({@link SOCBoardLarge#BOARD_ENCODING_LARGE}).
      * For v3, call {@link #getLandHexCoords()} and {@link #getNumberOnHexFromCoord(int)} instead.
      * @return the number layout; each element is valued 2-12.
      *     The robber hex is 0.  Water hexes are -1.
      * @throws UnsupportedOperationException if the board encoding doesn't support this method;
-     *     the v1 and v2 encodings do, but v3 ({@link #BOARD_ENCODING_LARGE}) does not.
+     *     the v1 and v2 encodings do, but v3 ({@link SOCBoardLarge#BOARD_ENCODING_LARGE}) does not.
      */
     public int[] getNumberLayout()
         throws UnsupportedOperationException
@@ -1836,7 +1378,7 @@ public class SOCBoard implements Serializable, Cloneable
      * Same order as {@link #getPortsFacing()}: Clockwise from upper-left.
      * The number of ports is {@link #getPortsCount()}.
      *<P>
-     * <b>Note:</b> The v3 layout ({@link #BOARD_ENCODING_LARGE}) stores more information
+     * <b>Note:</b> The v3 layout ({@link SOCBoardLarge#BOARD_ENCODING_LARGE}) stores more information
      * within the port layout array.  The port types are stored at the beginning, from index
      * 0 to {@link #getPortsCount()}-1.  If you call {@link #setPortsLayout(int[])}, be sure
      * to give it the entire array returned from here.
@@ -1866,13 +1408,7 @@ public class SOCBoard implements Serializable, Cloneable
      */
     public int[] getPortsFacing()
     {
-        switch (boardEncodingFormat)
-        {
-        case BOARD_ENCODING_6PLAYER:
-            return PORTS_FACING_V2;
-        default:
-            return PORTS_FACING_V1;
-        }
+        throw new UnsupportedOperationException(); // implemented in derived classes
     }
 
     /**
@@ -1895,13 +1431,7 @@ public class SOCBoard implements Serializable, Cloneable
      */
     public int[] getPortsEdges()
     {
-        switch (boardEncodingFormat)
-        {
-        case BOARD_ENCODING_6PLAYER:
-            return PORTS_EDGE_V2;
-        default:
-            return PORTS_EDGE_V1;
-        }
+        throw new UnsupportedOperationException(); // implemented in derived classes
     }
 
     /**
@@ -1928,29 +1458,13 @@ public class SOCBoard implements Serializable, Cloneable
     }
 
     /**
-     * set the board encoding format.
-     * Intended for client-side use.
-     * @param fmt  Board encoding format number
-     * @throws IllegalArgumentException if fmt &lt; 1 or > {@link #MAX_BOARD_ENCODING}
-     */
-    public void setBoardEncodingFormat(int fmt)
-        throws IllegalArgumentException
-    {
-        if ((fmt < 1) || (fmt > MAX_BOARD_ENCODING))
-            throw new IllegalArgumentException("Format out of range: " + fmt);
-        boardEncodingFormat = fmt;
-    }
-
-    /**
      * set the hexLayout.
-     * Please call {@link #setBoardEncodingFormat(int)} first,
-     * unless the format is {@link #BOARD_ENCODING_ORIGINAL}.
      *
      * @param hl  the hex layout.
-     *   For {@link #BOARD_ENCODING_ORIGINAL}: if <tt>hl[0]</tt> is {@link #WATER_HEX},
+     *   For {@link Standard4p#BOARD_ENCODING_ORIGINAL}: if <tt>hl[0]</tt> is {@link #WATER_HEX},
      *    the board is assumed empty and ports arrays won't be filled.
      * @throws UnsupportedOperationException if the board encoding doesn't support this method;
-     *     the v1 and v2 encodings do, but v3 ({@link #BOARD_ENCODING_LARGE}) does not.
+     *     the v1 and v2 encodings do, but v3 ({@link SOCBoardLarge#BOARD_ENCODING_LARGE}) does not.
      */
     public void setHexLayout(int[] hl)
         throws UnsupportedOperationException
@@ -1959,28 +1473,25 @@ public class SOCBoard implements Serializable, Cloneable
 
         if (hl[0] == WATER_HEX)
         {
-            /**
-             * this is a blank board
-             */
-            return;
+            return; // this is a blank board
         }
 
-        /**
+        /*
          * fill in the port node information, if it's part of the hex layout
          */
-        if (boardEncodingFormat != BOARD_ENCODING_ORIGINAL)
+        if (getBoardEncodingFormat() != Standard4p.BOARD_ENCODING_ORIGINAL)
             return;  // <---- port nodes are outside the hex layout ----
 
         if (nodeIDtoPortType == null)
-            nodeIDtoPortType = new HashMap<Integer,Integer>();
+            nodeIDtoPortType = new HashMap<>();
         else
             nodeIDtoPortType.clear();
 
-        for (int i = 0; i < PORTS_FACING_V1.length; ++i)
+        for (int i = 0; i < Standard4p.PORTS_FACING_V1.length; ++i)
         {
-            final int hexnum = PORTS_HEXNUM_V1[i];
+            final int hexnum = Standard4p.PORTS_HEXNUM_V1[i];
             final int ptype = getPortTypeFromHexType(hexLayout[hexnum]);
-            final int[] nodes = getAdjacentNodesToEdge_arr(PORTS_EDGE_V1[i]);
+            final int[] nodes = getAdjacentNodesToEdge_arr(Standard4p.PORTS_EDGE_V1[i]);
             placePort(ptype, -1, -1, nodes[0], nodes[1]);
         }
     }
@@ -1988,10 +1499,10 @@ public class SOCBoard implements Serializable, Cloneable
     /**
      * On the 6-player (v2 layout) board, each port's type, such as {@link #SHEEP_PORT}.
      * (In the standard board (v1), these are part of {@link #hexLayout} instead.)
-     * Same order as {@link #PORTS_FACING_V2}: Clockwise from upper-left.
+     * Same order as {@link Standard6p#PORTS_FACING_V2}: Clockwise from upper-left.
      *<P>
-     * <b>Note:</b> The v3 layout ({@link #BOARD_ENCODING_LARGE}) stores more information
-     * within the port layout array.  If you call {@link #setPortsLayout(int[])}, be sure
+     * <b>Note:</b> The v3 layout ({@link SOCBoardLarge#BOARD_ENCODING_LARGE}) stores more information
+     * within the port layout array.  If you call this method, be sure
      * you are giving all information returned by {@link #getPortsLayout()}, not just the
      * port types.
      *
@@ -2004,18 +1515,18 @@ public class SOCBoard implements Serializable, Cloneable
 
         // Clear any previous port layout info
         if (nodeIDtoPortType == null)
-            nodeIDtoPortType = new HashMap<Integer,Integer>();
+            nodeIDtoPortType = new HashMap<>();
         else
             nodeIDtoPortType.clear();
-        for (int i = 0; i < ports.length; ++i)
-            ports[i].removeAllElements();
+
+        for (Vector<Integer> port : ports) port.removeAllElements();
 
         // Place the new ports
-        for (int i = 0; i < PORTS_FACING_V2.length; ++i)
+        for (int i = 0; i < Standard6p.PORTS_FACING_V2.length; ++i)
         {
             final int ptype = portTypes[i];
-            final int[] nodes = getAdjacentNodesToEdge_arr(PORTS_EDGE_V2[i]);
-            placePort(ptype, -1, PORTS_FACING_V2[i], nodes[0], nodes[1]);
+            final int[] nodes = getAdjacentNodesToEdge_arr(Standard6p.PORTS_EDGE_V2[i]);
+            placePort(ptype, -1, Standard6p.PORTS_FACING_V2[i], nodes[0], nodes[1]);
         }
 
         // The v3 layout overrides this method in SOCBoardLarge.
@@ -2023,7 +1534,7 @@ public class SOCBoard implements Serializable, Cloneable
 
     /**
      * Given a hex type, return the port type.
-     * Used in {@link #BOARD_ENCODING_ORIGINAL}
+     * Used in {@link Standard4p#BOARD_ENCODING_ORIGINAL}
      * to set up port info in {@link #setHexLayout(int[])}.
      * @return the type of port given a hex type;
      *         in range {@link #MISC_PORT} to {@link #WOOD_PORT}.
@@ -2033,9 +1544,9 @@ public class SOCBoard implements Serializable, Cloneable
      * @see #getHexTypeFromCoord(int)
      * @see #getPortTypeFromNodeCoord(int)
      */
-    private final int getPortTypeFromHexType(final int hexType)
+    private int getPortTypeFromHexType(final int hexType)
     {
-        int portType = 0;
+        int portType;
 
         if ((hexType >= MISC_PORT_HEX) && (hexType <= 12))
         {
@@ -2051,12 +1562,12 @@ public class SOCBoard implements Serializable, Cloneable
 
     /**
      * Set the number layout.
-     * Valid for the v1 and v2 encodings, not v3 ({@link #BOARD_ENCODING_LARGE}).
+     * Valid for the v1 and v2 encodings, not v3 ({@link SOCBoardLarge#BOARD_ENCODING_LARGE}).
      * For v3, call {@link SOCBoardLarge#setLandHexLayout(int[])} instead.
      *
      * @param nl  the number layout, from {@link #getNumberLayout()}
      * @throws UnsupportedOperationException if the board encoding doesn't support this method;
-     *     the v1 and v2 encodings do, but v3 ({@link #BOARD_ENCODING_LARGE}) does not.
+     *     the v1 and v2 encodings do, but v3 ({@link SOCBoardLarge#BOARD_ENCODING_LARGE}) does not.
      */
     public void setNumberLayout(int[] nl)
         throws UnsupportedOperationException
@@ -2089,7 +1600,7 @@ public class SOCBoard implements Serializable, Cloneable
     /**
      * Get the number of ports on this board.  The original and 6-player
      * board layouts each have a constant number of ports.  The v3 layout
-     * ({@link #BOARD_ENCODING_LARGE}) has a varying amount of ports,
+     * ({@link SOCBoardLarge#BOARD_ENCODING_LARGE}) has a varying amount of ports,
      * set during {@link #makeNewBoard(Map)}.
      *
      * @return the number of ports on this board; might be 0 if
@@ -2098,13 +1609,7 @@ public class SOCBoard implements Serializable, Cloneable
      */
     public int getPortsCount()
     {
-        if (boardEncodingFormat == BOARD_ENCODING_ORIGINAL)
-            return PORTS_FACING_V1.length;
-        else
-            return PORTS_FACING_V2.length;
-
-        // v3 BOARD_ENCODING_LARGE overrides this method
-        // in SOCBoardLarge to return its port count.
+        throw new UnsupportedOperationException(); // implemented in derived classes
     }
 
     /**
@@ -2135,9 +1640,9 @@ public class SOCBoard implements Serializable, Cloneable
         if ((nodeCoord < 0) || (nodeIDtoPortType == null))
             return -1;
 
-        Integer ptype = nodeIDtoPortType.get(new Integer(nodeCoord));
+        Integer ptype = nodeIDtoPortType.get(nodeCoord);
         if (ptype != null)
-            return ptype.intValue();
+            return ptype;
         else
             return -1;
     }
@@ -2226,7 +1731,7 @@ public class SOCBoard implements Serializable, Cloneable
      * @see #getHexTypeFromCoord(int)
      * @since 1.1.08
      * @throws UnsupportedOperationException if the board encoding doesn't support this method;
-     *     the v1 and v2 encodings do, but v3 ({@link #BOARD_ENCODING_LARGE}) does not.
+     *     the v1 and v2 encodings do, but v3 ({@link SOCBoardLarge#BOARD_ENCODING_LARGE}) does not.
      */
     public int getHexNumFromCoord(final int hexCoord)
         throws UnsupportedOperationException
@@ -2324,17 +1829,14 @@ public class SOCBoard implements Serializable, Cloneable
         case SOCPlayingPiece.SHIP:  // fall through to ROAD
         case SOCPlayingPiece.ROAD:
             roads.addElement((SOCRoad)pp);
-
             break;
 
         case SOCPlayingPiece.SETTLEMENT:
             settlements.addElement((SOCSettlement)pp);
-
             break;
 
         case SOCPlayingPiece.CITY:
             cities.addElement((SOCCity)pp);
-
             break;
 
         }
@@ -2400,7 +1902,7 @@ public class SOCBoard implements Serializable, Cloneable
     /**
      * Width of this board in coordinates (not in number of hexes across.)
      * The maximum column coordinate.
-     * For the default size, see {@link #BOARD_ENCODING_ORIGINAL}.
+     * For the default size, see {@link Standard4p#BOARD_ENCODING_ORIGINAL}.
      * @since 1.1.06
      */
     public int getBoardWidth()
@@ -2411,7 +1913,7 @@ public class SOCBoard implements Serializable, Cloneable
     /**
      * Height of this board in coordinates (not in number of hexes across.)
      * The maximum row coordinate.
-     * For the default size, see {@link #BOARD_ENCODING_ORIGINAL}.
+     * For the default size, see {@link Standard4p#BOARD_ENCODING_ORIGINAL}.
      * @since 1.1.06
      */
     public int getBoardHeight()
@@ -2434,30 +1936,38 @@ public class SOCBoard implements Serializable, Cloneable
     }
 
     /**
-     * Get the encoding format of this board (for coordinates, etc).
-     * Some formats use a {@code SOCBoard} subclass like {@link SOCBoardLarge}.
-     *<P>
-     * See the encoding constants' javadocs for more documentation:
+     * The encoding format of board coordinates.
+     * The board size determines the required encoding format.
      *<UL>
-     * <LI> {@link #BOARD_ENCODING_ORIGINAL}
-     * <LI> {@link #BOARD_ENCODING_6PLAYER}
-     * <LI> {@link #BOARD_ENCODING_LARGE}
+     *<LI> 1 - Original format: hexadecimal 0x00 to 0xFF.
+     *       {@link Standard4p#BOARD_ENCODING_ORIGINAL}
+     *       Coordinate range is 0 to 15 (in decimal).
+     *       Port types and facings encoded within {@link #hexLayout}.
+     *<LI> 2 - 6-player board, variant of original format: hexadecimal 0x00 to 0xFF.
+     *       {@link Standard6p#BOARD_ENCODING_6PLAYER}
+     *       Coordinate range is 0 to 15 (in decimal).
+     *       Port types stored in {@link #portsLayout}.
+     *       Added in 1.1.08.
+     *<LI> 3 - Large board ({@link SOCBoardLarge#BOARD_ENCODING_LARGE}).
+     *       {@link SOCBoardLarge#BOARD_ENCODING_LARGE}
+     *       Coordinate range for rows,columns is each 0 to 255 decimal,
+     *       or altogether 0x0000 to 0xFFFF hex.
+     *       Arbitrary mix of land and water tiles.
+     *       Added in 2.0.00, implemented in {@link SOCBoardLarge}.
+     *       Activated with {@link SOCGameOption} <tt>"SBL"</tt>.
      *</UL>
-     * @return board coordinate-encoding format, from the list above
-     * @see #setBoardEncodingFormat(int)
-     * @see SOCBoard.BoardFactory#createBoard(Map, boolean, int)
      * @since 1.1.06
      */
     public int getBoardEncodingFormat()
     {
-        return boardEncodingFormat;
+        throw new UnsupportedOperationException(); // implemented in derived classes
     }
 
     /**
      * Adjacent node coordinates to an edge, within valid range to be on the board.
      *<P>
-     * For v1 and v2 encoding, this range is {@link #MINNODE_V1} to {@link #MAXNODE},
-     *   or {@link #MINNODE_V2} to {@link #MAXNODE}.
+     * For v1 and v2 encoding, this range is {@link Standard4p#MINNODE_V1} to {@link #MAXNODE},
+     *   or {@link Standard6p#MINNODE_V2} to {@link #MAXNODE}.
      * For v3 encoding, nodes are around all valid land or water hexes,
      *   and the board size is {@link #getBoardHeight()} x {@link #getBoardHeight()}.
      * @return the nodes that touch this edge, as a Vector of Integer coordinates
@@ -2465,18 +1975,18 @@ public class SOCBoard implements Serializable, Cloneable
      */
     public Vector<Integer> getAdjacentNodesToEdge(final int coord)
     {
-        Vector<Integer> nodes = new Vector<Integer>(2);
+        Vector<Integer> nodes = new Vector<>(2);
         final int[] narr = getAdjacentNodesToEdge_arr(coord);
         if ((narr[0] >= minNode) && (narr[0] <= MAXNODE))
-            nodes.addElement(new Integer(narr[0]));
+            nodes.addElement(narr[0]);
         if ((narr[1] >= minNode) && (narr[1] <= MAXNODE))
-            nodes.addElement(new Integer(narr[1]));
+            nodes.addElement(narr[1]);
         return nodes;
     }
 
     /**
      * Adjacent node coordinates to an edge.
-     * Does not check against range {@link #MINNODE_V1} to {@link #MAXNODE},
+     * Does not check against range {@link Standard4p#MINNODE_V1} to {@link #MAXNODE},
      * so nodes in the water (off the land board) may be returned.
      * @param coord  Edge coordinate; not checked for validity
      * @return the nodes that touch this edge, as an array of 2 integer coordinates
@@ -2488,7 +1998,7 @@ public class SOCBoard implements Serializable, Cloneable
     {
         int[] nodes = new int[2];
 
-        /**
+        /*
          * if the coords are (even, even), then
          * the road is '|'.
          */
@@ -2534,10 +2044,10 @@ public class SOCBoard implements Serializable, Cloneable
      */
     public Vector<Integer> getAdjacentEdgesToEdge(int coord)
     {
-        Vector<Integer> edges = new Vector<Integer>(4);
+        Vector<Integer> edges = new Vector<>(4);
         int tmp;
 
-        /**
+        /*
          * if the coords are (even, even), then
          * the road is '|'.
          */
@@ -2547,32 +2057,32 @@ public class SOCBoard implements Serializable, Cloneable
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(tmp);
             }
 
             tmp = coord + 0x01;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(tmp);
             }
 
             tmp = coord + 0x10;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(tmp);
             }
 
             tmp = coord - 0x01;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(tmp);
             }
         }
 
-        /**
+        /*
          * if the coords are (even, odd), then
          * the road is '/'.
          */
@@ -2582,62 +2092,62 @@ public class SOCBoard implements Serializable, Cloneable
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(tmp);
             }
 
             tmp = coord + 0x01;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(tmp);
             }
 
             tmp = coord + 0x11;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(tmp);
             }
 
             tmp = coord - 0x01;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(tmp);
             }
         }
         else
         {
-            /**
-             * otherwise the coords are (odd, even),
-             * and the road is '\'
+            /*
+              otherwise the coords are (odd, even),
+              and the road is '\'
              */
             tmp = coord - 0x10;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(tmp);
             }
 
             tmp = coord + 0x11;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(tmp);
             }
 
             tmp = coord + 0x10;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(tmp);
             }
 
             tmp = coord - 0x11;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(tmp);
             }
         }
 
@@ -2652,10 +2162,10 @@ public class SOCBoard implements Serializable, Cloneable
      */
     public Vector<Integer> getAdjacentHexesToNode(int coord)
     {
-        Vector<Integer> hexes = new Vector<Integer>(3);
+        Vector<Integer> hexes = new Vector<>(3);
         int tmp;
 
-        /**
+        /*
          * if the coords are (even, odd), then
          * the node is 'Y'.
          */
@@ -2665,26 +2175,26 @@ public class SOCBoard implements Serializable, Cloneable
 
             if ((tmp >= MINHEX) && (tmp <= MAXHEX))
             {
-                hexes.addElement(new Integer(tmp));
+                hexes.addElement(tmp);
             }
 
             tmp = coord + 0x10;
 
             if ((tmp >= MINHEX) && (tmp <= MAXHEX))
             {
-                hexes.addElement(new Integer(tmp));
+                hexes.addElement(tmp);
             }
 
             tmp = coord - 0x12;
 
             if ((tmp >= MINHEX) && (tmp <= MAXHEX))
             {
-                hexes.addElement(new Integer(tmp));
+                hexes.addElement(tmp);
             }
         }
         else
         {
-            /**
+            /*
              * otherwise the coords are (odd, even),
              * and the node is 'upside down Y'.
              */
@@ -2692,21 +2202,21 @@ public class SOCBoard implements Serializable, Cloneable
 
             if ((tmp >= MINHEX) && (tmp <= MAXHEX))
             {
-                hexes.addElement(new Integer(tmp));
+                hexes.addElement(tmp);
             }
 
             tmp = coord + 0x01;
 
             if ((tmp >= MINHEX) && (tmp <= MAXHEX))
             {
-                hexes.addElement(new Integer(tmp));
+                hexes.addElement(tmp);
             }
 
             tmp = coord - 0x01;
 
             if ((tmp >= MINHEX) && (tmp <= MAXHEX))
             {
-                hexes.addElement(new Integer(tmp));
+                hexes.addElement(tmp);
             }
         }
 
@@ -2721,11 +2231,11 @@ public class SOCBoard implements Serializable, Cloneable
      */
     public Vector<Integer> getAdjacentEdgesToNode(final int coord)
     {
-        Vector<Integer> edges = new Vector<Integer>(3);
+        Vector<Integer> edges = new Vector<>(3);
         int[] edgea = getAdjacentEdgesToNode_arr(coord);
         for (int i = edgea.length - 1; i>=0; --i)
             if (edgea[i] != -9)
-                edges.addElement(new Integer(edgea[i]));
+                edges.addElement(edgea[i]);
         return edges;
     }
 
@@ -2782,7 +2292,7 @@ public class SOCBoard implements Serializable, Cloneable
         //   Use % 0x22 to check.  (Coordinates of
         //   nodes going east are +0x22 at each hex.)
 
-        /**
+        /*
          * if the coords are (even, odd), then
          * the node is 'Y'.
          * otherwise the coords are (odd, even),
@@ -2939,7 +2449,7 @@ public class SOCBoard implements Serializable, Cloneable
         // See dissertation figures A.8, A.10
         if ((edgeCoord == nodeCoord) || (edgeCoord == (nodeCoord - 0x11)))
             return true;
-        /**
+        /*
          * if the coords are (even, odd), then
          * the node is 'Y' (figure A.8), otherwise is 'A' (figure A.10).
          */
@@ -2957,11 +2467,11 @@ public class SOCBoard implements Serializable, Cloneable
      */
     public Vector<Integer> getAdjacentNodesToNode(final int coord)
     {
-        Vector<Integer> nodes = new Vector<Integer>(3);
+        Vector<Integer> nodes = new Vector<>(3);
         int[] nodea = getAdjacentNodesToNode_arr(coord);
         for (int i = nodea.length - 1; i>=0; --i)
             if (nodea[i] != -9)
-                nodes.addElement(new Integer(nodea[i]));
+                nodes.addElement(nodea[i]);
         return nodes;
     }
 
@@ -3056,7 +2566,7 @@ public class SOCBoard implements Serializable, Cloneable
             break;
 
         case 2:  // N or S
-            /**
+            /*
              * if the coords are (even, odd), then
              * the node is 'Y'.
              */
@@ -3073,7 +2583,7 @@ public class SOCBoard implements Serializable, Cloneable
             }
             else
             {
-                /**
+                /*
                  * otherwise the coords are (odd, even),
                  * and the node is 'upside down Y' ('A').
                  */
@@ -3165,7 +2675,7 @@ public class SOCBoard implements Serializable, Cloneable
     {
         final int roadEdge;
 
-        /**
+        /*
          * See RST dissertation figures A.2, A.8, A.10.
          *
          * if the coords are (even, odd), then
@@ -3229,7 +2739,7 @@ public class SOCBoard implements Serializable, Cloneable
      */
     public Vector<Integer> getAdjacentHexesToHex(final int hexCoord, final boolean includeWater)
     {
-        Vector<Integer> hexes = new Vector<Integer>();
+        Vector<Integer> hexes = new Vector<>();
 
         getAdjacentHexes_AddIfOK(hexes, includeWater, hexCoord, -2,  0);  // NW (northwest)
         getAdjacentHexes_AddIfOK(hexes, includeWater, hexCoord,  0, +2);  // NE
@@ -3254,7 +2764,7 @@ public class SOCBoard implements Serializable, Cloneable
      * @param d2  Delta along axis 2
      * @since 1.1.07
      */
-    private final void getAdjacentHexes_AddIfOK
+    private void getAdjacentHexes_AddIfOK
         (Vector<Integer> addTo, final boolean includeWater, int hexCoord, final int d1, final int d2)
     {
         int a1 = ((hexCoord & 0xF0) >> 4) + d1;  // Axis-1 coordinate
@@ -3269,7 +2779,7 @@ public class SOCBoard implements Serializable, Cloneable
             && (includeWater
                 || ((hexLayout[hexIDtoNum[hexCoord]] <= MAX_LAND_HEX)
                     && (hexLayout[hexIDtoNum[hexCoord]] != WATER_HEX)) ))
-            addTo.addElement(new Integer(hexCoord));
+            addTo.addElement(hexCoord);
     }
 
     /**
@@ -3338,7 +2848,7 @@ public class SOCBoard implements Serializable, Cloneable
         // No valid edge has an F digit, so we need only
         // bounds-check subtraction vs 0, and addition+2 vs D.
 
-        /**
+        /*
          * if the coords are (even, even), then
          * the edge is '|'.  (Figure A.13)
          */
@@ -3364,7 +2874,7 @@ public class SOCBoard implements Serializable, Cloneable
             }
         }
 
-        /**
+        /*
          * if the coords are (even, odd), then
          * the edge is '/'.  (Figure A.11)
          */
@@ -3392,7 +2902,7 @@ public class SOCBoard implements Serializable, Cloneable
         }
         else
         {
-            /**
+            /*
              * otherwise the coords are (odd, even),
              * and the edge is '\'.  (Figure A.12)
              */
@@ -3476,7 +2986,7 @@ public class SOCBoard implements Serializable, Cloneable
     {
         if (node < 0)
             return false;
-        return nodesOnLand.contains(new Integer(node));
+        return nodesOnLand.contains(node);
     }
 
     /**
@@ -3487,7 +2997,7 @@ public class SOCBoard implements Serializable, Cloneable
      */
     public String nodeCoordToString(int node)
     {
-        String str;
+        StringBuilder sb;
         Vector<Integer> hexes = getAdjacentHexesToNode(node);
         if (hexes.isEmpty())
         {
@@ -3495,34 +3005,34 @@ public class SOCBoard implements Serializable, Cloneable
             return "(node 0x" + Integer.toHexString(node) + ")";
         }
 
-        int hex = hexes.get(0).intValue();
+        int hex = hexes.get(0);
         int number = getNumberOnHexFromCoord(hex);
 
         if (number == 0)
         {
-            str = "-";
+            sb = new StringBuilder("-");
         }
         else
         {
-            str = Integer.toString(number);
+            sb = new StringBuilder(Integer.toString(number));
         }
 
         for (int i = 1; i<hexes.size(); ++i)
         {
-            hex = hexes.get(i).intValue();
+            hex = hexes.get(i);
             number = getNumberOnHexFromCoord(hex);
 
             if (number == 0)
             {
-                str += "/-";
+                sb.append("/-");
             }
             else
             {
-                str += ("/" + number);
+                sb.append("/").append(number);
             }
         }
 
-        return str;
+        return sb.toString();
     }
 
     /**
@@ -3537,7 +3047,7 @@ public class SOCBoard implements Serializable, Cloneable
         int number1;
         int number2;
 
-        /**
+        /*
          * if the coords are (even, even), then
          * the road is '|'.
          */
@@ -3547,7 +3057,7 @@ public class SOCBoard implements Serializable, Cloneable
             number2 = getNumberOnHexFromCoord(edge + 0x11);
         }
 
-        /**
+        /*
          * if the coords are (even, odd), then
          * the road is '/'.
          */
@@ -3558,7 +3068,7 @@ public class SOCBoard implements Serializable, Cloneable
         }
         else
         {
-            /**
+            /*
              * otherwise the coords are (odd, even),
              * and the road is '\'
              */
@@ -3571,10 +3081,6 @@ public class SOCBoard implements Serializable, Cloneable
         return str;
     }
 
-    //
-    // Nested classes for board factory
-    //
-
     /**
      * Board Factory for creating new boards for games at the client or server.
      * (The server's version of {@link SOCBoardLarge} isolates makeNewBoard methods.)
@@ -3585,17 +3091,17 @@ public class SOCBoard implements Serializable, Cloneable
      * @author Jeremy D Monin
      * @since 2.0.00
      */
-    public static interface BoardFactory
+    public interface BoardFactory
     {
         /**
          * Create a new Settlers of Catan Board based on <tt>gameOpts</tt>; this is a factory method.
          * @param gameOpts  game's options if any, otherwise null
          * @param largeBoard  true if {@link SOCBoardLarge} should be used (v3 encoding
-         *     {@link SOCBoard#BOARD_ENCODING_LARGE BOARD_ENCODING_LARGE})
+         *     {@link SOCBoardLarge#BOARD_ENCODING_LARGE BOARD_ENCODING_LARGE})
          * @param maxPlayers Maximum players; must be 4 or 6.
          * @throws IllegalArgumentException if <tt>maxPlayers</tt> is not 4 or 6
          */
-        public SOCBoard createBoard
+        SOCBoard createBoard
             (final Map<String,SOCGameOption> gameOpts, final boolean largeBoard, final int maxPlayers)
             throws IllegalArgumentException;
 
@@ -3611,25 +3117,6 @@ public class SOCBoard implements Serializable, Cloneable
     {
         /**
          * Create a new Settlers of Catan Board based on <tt>gameOpts</tt>; this is a factory method.
-         * Static for fallback access from other factory implementations.
-         *
-         * @param gameOpts  if game has options, map of {@link SOCGameOption}; otherwise null.
-         * @param largeBoard  true if {@link SOCBoardLarge} should be used (v3 encoding)
-         * @param maxPlayers Maximum players; must be 4 or 6.
-         * @throws IllegalArgumentException if <tt>maxPlayers</tt> is not 4 or 6
-         */
-        public static SOCBoard staticCreateBoard
-            (final Map<String,SOCGameOption> gameOpts, final boolean largeBoard, final int maxPlayers)
-            throws IllegalArgumentException
-        {
-            if (! largeBoard)
-                return new SOCBoard(gameOpts, maxPlayers);
-            else
-                return new SOCBoardLarge(gameOpts, maxPlayers);
-        }
-
-        /**
-         * Create a new Settlers of Catan Board based on <tt>gameOpts</tt>; this is a factory method.
          *<P>
          * From v1.1.11 through all 1.x.xx, this was SOCBoard.createBoard.  Moved to new factory class in 2.0.00.
          *
@@ -3642,7 +3129,16 @@ public class SOCBoard implements Serializable, Cloneable
             (final Map<String,SOCGameOption> gameOpts, final boolean largeBoard, final int maxPlayers)
             throws IllegalArgumentException
         {
-            return staticCreateBoard(gameOpts, largeBoard, maxPlayers);
+            if (!largeBoard) {
+                if (maxPlayers == 6) {
+                    return new Standard6p(gameOpts);
+                } else {
+                    return new Standard4p(gameOpts);
+                }
+            }
+            else {
+                return new SOCBoardLarge(gameOpts, maxPlayers);
+            }
         }
 
     }  // nested class DefaultBoardFactory

--- a/src/main/java/soc/game/SOCBoardLarge.java
+++ b/src/main/java/soc/game/SOCBoardLarge.java
@@ -36,7 +36,7 @@ import soc.util.IntPair;
 /**
  * Sea board layout: A representation of a larger (up to 127 x 127 hexes) JSettlers board,
  * with an arbitrary mix of land and water tiles.
- * Implements {@link SOCBoard#BOARD_ENCODING_LARGE}.
+ * Implements {@link SOCBoardLarge#BOARD_ENCODING_LARGE}.
  * Activated with {@link SOCGameOption} {@code "SBL"}.
  * For the board layout geometry, see the "Coordinate System" section here.
  *<P>
@@ -228,7 +228,19 @@ public class SOCBoardLarge extends SOCBoard
     private static final long serialVersionUID = 2000L;
 
     /**
-     * This board encoding {@link SOCBoard#BOARD_ENCODING_LARGE}
+     * Sea board format (v3) used with {@link SOCBoardLarge} for {@link #getBoardEncodingFormat()}:
+     * Allows up to 127 x 127 board with an arbitrary mix of land and water tiles.
+     * Land, water, and port locations/facings are no longer hardcoded.
+     * Use {@link #getPortsCount()} to get the number of ports.
+     * For other port information, use the same methods as in {@link Standard6p#BOARD_ENCODING_6PLAYER}.
+     *<P>
+     * Activated with {@link SOCGameOption} {@code "SBL"}.
+     * @since 2.0.00
+     */
+    public static final int BOARD_ENCODING_LARGE = 3;
+
+    /**
+     * This board encoding {@link SOCBoardLarge#BOARD_ENCODING_LARGE}
      * was introduced in version 2.0.00 (2000)
      */
     public static final int VERSION_FOR_ENCODING_LARGE = 2000;
@@ -651,7 +663,6 @@ public class SOCBoardLarge extends SOCBoard
      * for how the board is filled when the game begins.
      * Board height and width will be the default, {@link #BOARDHEIGHT_LARGE} by {@link #BOARDWIDTH_LARGE}.
      *<P>
-     * Only the client uses this constructor.
      * @param gameOpts  if game has options, map of {@link SOCGameOption}; otherwise null.
      * @param maxPlayers Maximum players; must be 4 or 6
      * @throws IllegalArgumentException if <tt>maxPlayers</tt> is not 4 or 6
@@ -676,12 +687,15 @@ public class SOCBoardLarge extends SOCBoard
         (final Map<String,SOCGameOption> gameOpts, final int maxPlayers, final IntPair boardHeightWidth)
         throws IllegalArgumentException
     {
-        super(BOARD_ENCODING_LARGE, MAX_LAND_HEX_LG);
-        if ((maxPlayers != 4) && (maxPlayers != 6))
+        if (maxPlayers != 4 && maxPlayers != 6)
             throw new IllegalArgumentException("maxPlayers: " + maxPlayers);
+
         if (boardHeightWidth == null)
             throw new IllegalArgumentException("boardHeightWidth null");
+
         this.maxPlayers = maxPlayers;
+
+        initializePorts();
 
         final int bH = boardHeightWidth.a, bW = boardHeightWidth.b;
         setBoardBounds(bH, bW);
@@ -708,6 +722,12 @@ public class SOCBoardLarge extends SOCBoard
         portsCount = 0;
         pirateHex = 0;
         prevPirateHex = 0;
+    }
+
+    @Override
+    public int getBoardEncodingFormat()
+    {
+        return BOARD_ENCODING_LARGE;
     }
 
     /**
@@ -2306,7 +2326,7 @@ public class SOCBoardLarge extends SOCBoard
      * @since 1.1.12
      */
     @Override
-    HashSet<Integer> initPlayerLegalRoads()
+    public HashSet<Integer> initPlayerLegalRoads()
     {
         return new HashSet<Integer>(legalRoadEdges);
     }

--- a/src/main/java/soc/game/SOCGame.java
+++ b/src/main/java/soc/game/SOCGame.java
@@ -883,7 +883,7 @@ public class SOCGame implements Serializable, Cloneable
     /**
      * Is this game played on the {@link SOCBoardLarge} large board / sea board?
      * If true, our board's {@link SOCBoard#getBoardEncodingFormat()}
-     * must be {@link SOCBoard#BOARD_ENCODING_LARGE}.
+     * must be {@link SOCBoardLarge#BOARD_ENCODING_LARGE}.
      * When {@code hasSeaBoard}, {@link #getBoard()} can always be cast to {@link SOCBoardLarge}.
      *<P>
      * The 6-player extensions ({@link #maxPlayers} == 6) are orthogonal to {@code hasSeaBoard}
@@ -2404,7 +2404,7 @@ public class SOCGame implements Serializable, Cloneable
         throws IllegalStateException
     {
         final int bef = board.getBoardEncodingFormat();
-        if (bef < SOCBoard.BOARD_ENCODING_LARGE)
+        if (bef != SOCBoardLarge.BOARD_ENCODING_LARGE)
             throw new IllegalStateException("board encoding: " + bef);
 
         final int[] landHex = board.getLandHexCoords();

--- a/src/main/java/soc/game/SOCPlayer.java
+++ b/src/main/java/soc/game/SOCPlayer.java
@@ -63,7 +63,7 @@ import java.util.Vector;
  * segments, will another potential settlement location be set.
  *<P>
  * If the board layout changes from game to game, as with {@link SOCBoardLarge} /
- * {@link SOCBoard#BOARD_ENCODING_LARGE}, use these methods to update the player's board data
+ * {@link SOCBoardLarge#BOARD_ENCODING_LARGE}, use these methods to update the player's board data
  * after {@link SOCBoard#makeNewBoard(Map)}, in this order:
  *<UL>
  * <LI> {@link #getPlayerNumber()}.{@link SOCPlayerNumbers#setLandHexCoordinates(int[]) setLandHexCoordinates(int[])}

--- a/src/main/java/soc/game/SOCPlayerNumbers.java
+++ b/src/main/java/soc/game/SOCPlayerNumbers.java
@@ -77,9 +77,9 @@ public class SOCPlayerNumbers
     private Hashtable<Integer, Vector<IntPair>> numberAndResourceForHex;
 
     /**
-     * Reference to either {@link SOCBoard#HEXCOORDS_LAND_V1} or {@link SOCBoard#HEXCOORDS_LAND_V2}.
+     * Reference to either {@link Standard4p#HEXCOORDS_LAND_V1} or {@link Standard6p#HEXCOORDS_LAND_V2}.
      * Hex coordinates for each land hex on the board, via {@link SOCBoard#getLandHexCoords()}.
-     * In {@link SOCBoard#BOARD_ENCODING_LARGE}, if the game hasn't yet called
+     * In {@link SOCBoardLarge#BOARD_ENCODING_LARGE}, if the game hasn't yet called
      * {@link SOCBoard#makeNewBoard(Map)}, this may be {@code null}.
      * @since 1.1.08
      */
@@ -88,7 +88,7 @@ public class SOCPlayerNumbers
     /**
      * Is this game played on the {@link SOCBoardLarge} large board / sea board?
      * If true, the board's {@link SOCBoard#getBoardEncodingFormat()}
-     * must be {@link SOCBoard#BOARD_ENCODING_LARGE}.
+     * must be {@link SOCBoardLarge#BOARD_ENCODING_LARGE}.
      *<P>
      * When <tt>hasSeaBoard</tt>, {@link SOCBoardLarge#GOLD_HEX} is tracked.
      * When false, it's ignored because the same numeric value in the previous
@@ -134,7 +134,7 @@ public class SOCPlayerNumbers
     /**
      * the constructor for a player's dice-resource numbers.
      *<P>
-     * If using {@link SOCBoard#BOARD_ENCODING_LARGE}, and this is the start of
+     * If using {@link SOCBoardLarge#BOARD_ENCODING_LARGE}, and this is the start of
      * a game that hasn't yet created the layout:  The land hex coordinates
      * will need to be updated later when the board layout is created and sent;
      * call {@link #setLandHexCoordinates(int[])} at that time.
@@ -149,13 +149,7 @@ public class SOCPlayerNumbers
         throws IllegalArgumentException
     {
         final int boardEncodingFormat = board.getBoardEncodingFormat();
-        if ((boardEncodingFormat < SOCBoard.BOARD_ENCODING_ORIGINAL)
-            || (boardEncodingFormat > SOCBoard.BOARD_ENCODING_LARGE))
-        {
-            throw new IllegalArgumentException("boardEncodingFormat: " + boardEncodingFormat);
-        }
-
-        hasSeaBoard = (boardEncodingFormat == SOCBoard.BOARD_ENCODING_LARGE);
+        hasSeaBoard = boardEncodingFormat == SOCBoardLarge.BOARD_ENCODING_LARGE;
         landHexCoords = board.getLandHexCoords();
         //   landHexCoords might be null for BOARD_ENCODING_LARGE
         //   if the layout isn't yet created in SOCBoardLarge.makeNewBoard.

--- a/src/main/java/soc/game/Standard4p.java
+++ b/src/main/java/soc/game/Standard4p.java
@@ -1,0 +1,208 @@
+package soc.game;
+
+import java.util.Map;
+
+/**
+ * A standard 4p board with 19 land hexes and 18 sea hexes layed out in a
+ * concentric way
+ */
+public class Standard4p extends SOCBoard {
+
+    /**
+     * Each port's type, such as {@link #SHEEP_PORT}, on standard board.
+     * Same order as {@link #PORTS_FACING_V1}. {@link #MISC_PORT} is 0.
+     * @since 1.1.08
+     */
+    public final static int[] PORTS_TYPE_V1 = {
+        0, 0, 0, 0, CLAY_PORT, ORE_PORT, SHEEP_PORT, WHEAT_PORT, WOOD_PORT };
+
+    /**
+     * 4-player original format (v1) for {@link #getBoardEncodingFormat()}:
+     * Hexadecimal 0x00 to 0xFF along 2 diagonal axes.
+     * Coordinate range on each axis is 0 to 15 decimal. In hex:<pre>
+     *   Hexes: 11 to DD
+     *   Nodes: 01 or 10, to FE or EF
+     *   Edges: 00 to EE </pre>
+     *<P>
+     * See the Dissertation PDF for details.
+     * @since 1.1.06
+     */
+    public static final int BOARD_ENCODING_ORIGINAL = 1;
+    /**
+     * Land-hex coordinates in standard board ({@link #BOARD_ENCODING_ORIGINAL}).
+     * @since 1.1.08
+     */
+    public final static int[] HEXCOORDS_LAND_V1 =
+    {
+        0x33, 0x35, 0x37, 0x53, 0x55, 0x57, 0x59, 0x73, 0x75, 0x77, 0x79, 0x7B,
+        0x95, 0x97, 0x99, 0x9B, 0xB7, 0xB9, 0xBB
+    };
+    /**
+     * Land hex types on the original 4-player board layout (v1).
+     * For more information see {@link #makeNewBoard_placeHexes(int[], int[], int[], SOCGameOption)}.
+     * @since 2.0.00
+     */
+    public static final int[] makeNewBoard_landHexTypes_v1 =
+        { DESERT_HEX, CLAY_HEX, CLAY_HEX, CLAY_HEX,
+            ORE_HEX, ORE_HEX, ORE_HEX,
+            SHEEP_HEX, SHEEP_HEX, SHEEP_HEX, SHEEP_HEX,
+            WHEAT_HEX, WHEAT_HEX, WHEAT_HEX, WHEAT_HEX,
+            WOOD_HEX, WOOD_HEX, WOOD_HEX, WOOD_HEX };
+    /**
+     * Dice numbers in the original 4-player board layout, in order along {@code numPath} ({@link Standard4p#makeNewBoard_numPaths_v1}).
+     * For more information see {@link #makeNewBoard_placeHexes(int[], int[], int[], SOCGameOption)}.
+     * @since 2.0.00
+     */
+    public static final int[] makeNewBoard_diceNums_v1 =
+        { 5, 2, 6, 3, 8, 10, 9, 12, 11, 4, 8, 10, 9, 4, 5, 6, 3, 11 };
+
+    /**
+     * largest coordinate value for an edge, in the v1 encoding.
+     * Named <tt>MAXEDGE</tt> before v1.1.11 ; the name change is a
+     * reminder that {@link Standard6p#MAXEDGE_V2} represents a different encoding.
+     * @since 1.1.11
+     */
+    protected static final int MAXEDGE_V1 = 0xCC;
+
+    /**
+     * smallest coordinate value for an edge, in the v1 encoding.
+     * Named <tt>MINEDGE</tt> before v1.1.11 ; the name change is a
+     * reminder that {@link Standard6p#MINEDGE_V2} has a different value.
+     * @since 1.1.11
+     */
+    protected static final int MINEDGE_V1 = 0x22;
+
+    /**
+     * smallest coordinate value for a node on land, in the v1 encoding.
+     * Named <tt>MINNODE</tt> before v1.1.11 ; the name change is a
+     * reminder that {@link Standard6p#MINNODE_V2} has a different value.
+     * @since 1.1.11
+     */
+    protected static final int MINNODE_V1 = 0x23;
+
+    /**
+     * Each port's hex number within {@link #hexLayout} on standard board.
+     * Same order as {@link #PORTS_FACING_V1}:
+     * Clockwise from upper-left (hex coordinate 0x17).
+     * @since 1.1.08
+     */
+    final static int[] PORTS_HEXNUM_V1 = { 0, 2, 8, 21, 32, 35, 33, 22, 9 };
+
+    /**
+     * Each port's <em>facing</em> towards land, on the standard board.
+     * Ordered clockwise from upper-left (hex coordinate 0x17).
+     * Port Facing is the direction from the port hex/edge, to the land hex touching it
+     * which will have 2 nodes where a port settlement/city can be built.
+     * Facing 2 is east ({@link #FACING_E}), 3 is SE, 4 is SW, etc; see {@link #hexLayout}.
+     * @since 1.1.08
+     */
+    final static int[] PORTS_FACING_V1 =
+    {
+        FACING_SE, FACING_SW, FACING_SW, FACING_W, FACING_NW, FACING_NW, FACING_NE, FACING_E, FACING_E
+    };
+
+    /**
+     * Each port's 2 node coordinates on standard board.
+     * Same order as {@link Standard4p#PORTS_FACING_V1}:
+     * Clockwise from upper-left (hex coordinate 0x17).
+     * @since 1.1.08
+     */
+    final static int[] PORTS_EDGE_V1 =
+    {
+        0x27,  // Port touches the upper-left land hex, port facing land to its SouthEast
+        0x5A,  // Touches middle land hex of top row, port facing SW
+        0x9C,  // Touches rightmost land hex of row above middle, SW
+        0xCC,  // Rightmost of middle-row land hex, W
+        0xC9,  // Rightmost land hex below middle, NW
+        0xA5,  // Port touches middle hex of bottom row, facing NW
+        0x72,  // Leftmost of bottom row, NE
+        0x42,  // Leftmost land hex of row below middle, E
+        0x24   // Leftmost land hex above middle, facing E
+    };
+
+    /**
+     * Possible number paths for 4-player original board.
+     * {@link #makeNewBoard(Map)} randomly chooses one path (one 1-dimensional array)
+     * to be used as <tt>numPath[]</tt> in
+     * {@link #makeNewBoard_placeHexes(int[], int[], int[], SOCGameOption)}.
+     */
+    final static int[][] makeNewBoard_numPaths_v1 =
+    {
+        // Numbers are indexes within hexLayout (also in numberLayout) for each land hex.
+        // See the hexLayout javadoc for how the indexes are arranged on the board layout.
+
+        // counterclockwise from southwest
+        {
+            29, 30, 31, 26, 20, 13, 7, 6, 5, 10, 16, 23,  // outermost hexes
+            24, 25, 19, 12, 11, 17,    18  // middle ring, center hex
+        },
+
+        // clockwise from southwest
+        {
+            29, 23, 16, 10, 5, 6, 7, 13, 20, 26, 31, 30,
+            24, 17, 11, 12, 19, 25,    18
+        },
+
+        // counterclockwise from east corner
+        {
+            20, 13, 7, 6, 5, 10, 16, 23, 29, 30, 31, 26,
+            19, 12, 11, 17, 24, 25,    18
+        },
+
+        // clockwise from east corner
+        {
+            20, 26, 31, 30, 29, 23, 16, 10, 5, 6, 7, 13,
+            19, 25, 24, 17, 11, 12,    18
+        },
+
+        // counterclockwise from northwest
+        {
+            5, 10, 16, 23, 29, 30, 31, 26, 20, 13, 7, 6,
+            11, 17, 24, 25, 19, 12,    18
+        },
+
+        // clockwise from northwest
+        {
+            5, 6, 7, 13, 20, 26, 31, 30, 29, 23, 16, 10,
+            11, 12, 19, 25, 24, 17,    18
+        }
+    };
+
+    public Standard4p(Map<String, SOCGameOption> gameOpts) {
+        super(gameOpts, 4);
+        minEdge = MINEDGE_V1;
+        maxEdge = MAXEDGE_V1;
+        minNode = MINNODE_V1;
+    }
+
+    @Override
+    public int getBoardEncodingFormat()
+    {
+        return BOARD_ENCODING_ORIGINAL;
+    }
+
+    @Override
+    public int[] getPortsFacing()
+    {
+        return Standard4p.PORTS_FACING_V1;
+    }
+
+    @Override
+    public int[] getPortsEdges()
+    {
+        return Standard4p.PORTS_EDGE_V1;
+    }
+
+    @Override
+    public int[] getLandHexCoords()
+    {
+        return Standard4p.HEXCOORDS_LAND_V1;
+    }
+
+    @Override
+    public int getPortsCount()
+    {
+        return Standard4p.PORTS_FACING_V1.length;
+    }
+
+}

--- a/src/main/java/soc/game/Standard6p.java
+++ b/src/main/java/soc/game/Standard6p.java
@@ -1,0 +1,202 @@
+package soc.game;
+
+import java.util.Map;
+
+public class Standard6p extends SOCBoard {
+
+    /**
+     * Each port's type, such as {@link #SHEEP_PORT}, on 6-player board.
+     * Same order as {@link #PORTS_FACING_V2}. {@link #MISC_PORT} is 0.
+     * @since 1.1.08
+     */
+    public final static int[] PORTS_TYPE_V2 =
+        { 0, 0, 0, 0, SOCBoard.CLAY_PORT, SOCBoard.ORE_PORT, SOCBoard.SHEEP_PORT, SOCBoard.WHEAT_PORT, SOCBoard.WOOD_PORT, SOCBoard.MISC_PORT, SOCBoard.SHEEP_PORT };
+
+    /**
+     * 6-player format (v2) for {@link #getBoardEncodingFormat()}:
+     * Land hexes are same encoding as {@link Standard4p#BOARD_ENCODING_ORIGINAL}.
+     * Land starts 1 extra hex west of standard board,
+     * and has an extra row of land at north and south end.
+     *<P>
+     * Ports are not part of {@link #hexLayout} because their
+     * coordinates wouldn't fit within 2 hex digits.
+     * Instead, see {@link #getPortTypeFromNodeCoord(int)},
+     *   {@link #getPortsEdges()}, {@link #getPortsFacing()},
+     *   {@link #getPortCoordinates(int)} or {@link #getPortsLayout()}.
+     * @since 1.1.08
+     */
+    public static final int BOARD_ENCODING_6PLAYER = 2;
+
+    /**
+     * Land-hex coordinates in 6-player board ({@link #BOARD_ENCODING_6PLAYER}).
+     * @since 1.1.08.
+     */
+    public final static int[] HEXCOORDS_LAND_V2 =
+    {
+        0x11, 0x13, 0x15, 0x17,      // First diagonal row (moving NE from 0x11)
+        0x31, 0x33, 0x35, 0x37, 0x39,
+        0x51, 0x53, 0x55, 0x57, 0x59, 0x5B,
+        0x71, 0x73, 0x75, 0x77, 0x79, 0x7B,
+        0x93, 0x95, 0x97, 0x99, 0x9B,
+        0xB5, 0xB7, 0xB9, 0xBB       // Last diagonal row (NE from 0xB5)
+    };
+    /**
+     * Land hex types on the 6-player board layout (v2).
+     * For more information see {@link #makeNewBoard_placeHexes(int[], int[], int[], SOCGameOption)}.
+     * @since 2.0.00
+     */
+    public static final int[] makeNewBoard_landHexTypes_v2 =
+        {
+            SOCBoard.DESERT_HEX, SOCBoard.CLAY_HEX, SOCBoard.CLAY_HEX, SOCBoard.CLAY_HEX, SOCBoard.ORE_HEX, SOCBoard.ORE_HEX, SOCBoard.ORE_HEX,
+            SOCBoard.SHEEP_HEX, SOCBoard.SHEEP_HEX, SOCBoard.SHEEP_HEX, SOCBoard.SHEEP_HEX,
+            SOCBoard.WHEAT_HEX, SOCBoard.WHEAT_HEX, SOCBoard.WHEAT_HEX, SOCBoard.WHEAT_HEX,
+            SOCBoard.WOOD_HEX, SOCBoard.WOOD_HEX, SOCBoard.WOOD_HEX, SOCBoard.WOOD_HEX,   // last line of v1's hexes
+            SOCBoard.DESERT_HEX, SOCBoard.CLAY_HEX, SOCBoard.CLAY_HEX, SOCBoard.ORE_HEX, SOCBoard.ORE_HEX, SOCBoard.SHEEP_HEX, SOCBoard.SHEEP_HEX,
+            SOCBoard.WHEAT_HEX, SOCBoard.WHEAT_HEX, SOCBoard.WOOD_HEX, SOCBoard.WOOD_HEX
+        };
+    /**
+     * Dice numbers in the 6-player board layout, in order along {@code numPath} ({@link Standard6p#makeNewBoard_numPaths_v2}).
+     * For more information see {@link #makeNewBoard_placeHexes(int[], int[], int[], SOCGameOption)}.
+     * @since 2.0.00
+     */
+    public static final int[] makeNewBoard_diceNums_v2 =
+        {
+            2,   5,  4,  6 , 3, // A-E
+            9,   8, 11, 11, 10, // F-J
+            6,   3,  8,  4,  8, // K-O
+            10, 11, 12, 10,  5, // P-T
+            4,   9,  5,  9, 12, // U-Y
+            3,   2,  6          // Za-Zc
+        };
+    /**
+     * largest coordinate value for an edge, in the v2 encoding
+     * @since 1.1.08
+     */
+    protected static final int MAXEDGE_V2 = 0xCC;
+
+    /**
+     * smallest coordinate value for an edge, in the v2 encoding
+     * @since 1.1.08
+     */
+    protected static final int MINEDGE_V2 = 0x00;
+
+    /**
+     * smallest coordinate value for a node on land, in the v2 encoding
+     * @since 1.1.08
+     */
+    protected static final int MINNODE_V2 = 0x01;
+
+    /**
+     * Each port's <em>facing,</em> on 6-player board.
+     * Ordered clockwise from upper-left (hex coordinate 0x17, which is land in the V2 layout).
+     * Port Facing is the direction from the port hex/edge, to the land hex touching it
+     * which will have 2 nodes where a port settlement/city can be built.
+     * Within the board orientation (not the rotated visual orientation),
+     * facing 2 is east ({@link #FACING_E}), 3 is SE, 4 is SW, etc.
+     * @since 1.1.08
+     */
+    final static int[] PORTS_FACING_V2 =
+    {
+        SOCBoard.FACING_SE, SOCBoard.FACING_SW, SOCBoard.FACING_SW, SOCBoard.FACING_W, SOCBoard.FACING_W, SOCBoard.FACING_NW,
+        SOCBoard.FACING_NW, SOCBoard.FACING_NE, SOCBoard.FACING_NE, SOCBoard.FACING_E, SOCBoard.FACING_SE
+    };
+    /**
+     * Each port's edge coordinate on the 6-player board.
+     * This is the edge whose 2 end nodes can be used to build port settlements/cities.
+     * Same order as {@link Standard6p#PORTS_FACING_V2}:
+     * Clockwise from upper-left (hex coordinate 0x17, which is land in the V2 layout).
+     * @since 1.1.08
+     */
+    final static int[] PORTS_EDGE_V2 =
+    {
+        0x07,  // Port touches the upper-left land hex, port facing land to its SouthEast
+        0x3A,  // Touches middle land hex of top row, port facing SW
+        0x7C,  // Touches rightmost land hex of row below top, SW
+        0xAC,  // Touches rightmost land hex of row above middle, W
+        0xCA,  // Touches rightmost land hex of row below middle, W
+        0xC7,  // Touches rightmost land hex of row above bottom, NW
+        0xA3,  // Touches middle land hex of bottom row, NW
+        0x70,  // Touches bottom-left land hex, NE
+        0x30,  // Touches leftmost land hex of row below middle, NE
+        0x00,  // Leftmost hex of middle row, E
+        0x03   // Touches leftmost land hex of row above middle, SE
+    };
+    /**
+     * Possible number paths for 6-player board.
+     * {@link #makeNewBoard(Map)} randomly chooses one path (one 1-dimensional array)
+     * to be used as <tt>numPath[]</tt> in
+     * {@link #makeNewBoard_placeHexes(int[], int[], int[], SOCGameOption)}.
+     */
+    final static int[][] makeNewBoard_numPaths_v2 =
+    {
+        // Numbers are indexes within hexLayout (also in numberLayout) for each land hex.
+        // See the hexLayout javadoc for how the indexes are arranged on the board layout,
+        // and remember that the 6-player board is visually rotated clockwise 90 degrees;
+        // visual "North" used here is West internally in the board layout.
+
+        // clockwise from north
+        {
+            15, 9, 4, 0, 1, 2, 7, 13, 20, 26, 31, 35, 34, 33, 28, 22,  // outermost hexes
+            16, 10, 5, 6, 12, 19, 25, 30, 29, 23,  // middle ring of hexes
+            17, 11, 18, 24                         // center hexes
+        },
+
+        // counterclockwise from north
+        {
+            15, 22, 28, 33, 34, 35, 31, 26, 20, 13, 7, 2, 1, 0, 4, 9,
+            16, 23, 29, 30, 25, 19, 12, 6, 5, 10,
+            17, 24, 18, 11
+        },
+
+        // clockwise from south
+        {
+            20, 26, 31, 35, 34, 33, 28, 22, 15, 9, 4, 0, 1, 2, 7, 13,
+            19, 25, 30, 29, 23, 16, 10, 5, 6, 12,
+            18, 24, 17, 11
+        },
+
+        // counterclockwise from south
+        {
+            20, 13, 7, 2, 1, 0, 4, 9, 15, 22, 28, 33, 34, 35, 31, 26,
+            19, 12, 6, 5, 10, 16, 23, 29, 30, 25,
+            18, 11, 17, 24
+        }
+    };
+
+    protected Standard6p(Map<String, SOCGameOption> gameOpts) throws IllegalArgumentException {
+        super(gameOpts, 6);
+        minEdge = MINEDGE_V2;
+        maxEdge = MAXEDGE_V2;
+        minNode = MINNODE_V2;
+    }
+
+    @Override
+    public int getBoardEncodingFormat()
+    {
+        return BOARD_ENCODING_6PLAYER;
+    }
+
+    @Override
+    public int[] getPortsFacing()
+    {
+        return Standard6p.PORTS_FACING_V2;
+    }
+
+    @Override
+    public int[] getPortsEdges()
+    {
+        return Standard6p.PORTS_EDGE_V2;
+    }
+
+    @Override
+    public int[] getLandHexCoords()
+    {
+        return Standard6p.HEXCOORDS_LAND_V2;
+    }
+
+    @Override
+    public int getPortsCount()
+    {
+        return Standard6p.PORTS_FACING_V2.length;
+    }
+}

--- a/src/main/java/soc/message/SOCBoardLayout.java
+++ b/src/main/java/soc/message/SOCBoardLayout.java
@@ -23,6 +23,7 @@ package soc.message;
 import java.util.StringTokenizer;
 
 import soc.game.SOCBoard;
+import soc.game.Standard4p;
 
 
 /**
@@ -31,7 +32,7 @@ import soc.game.SOCBoard;
  * about any player's pieces on the board (see {@link SOCPutPiece PUTPIECE}).
  *<P>
  * This message sends the standard board layout for the original
- * 4-player game, {@link soc.game.SOCBoard#BOARD_ENCODING_ORIGINAL}.
+ * 4-player game, {@link Standard4p#BOARD_ENCODING_ORIGINAL}.
  * As of version 1.1.08 there are newer board layouts for game expansions
  * and 6-player extensions: See {@link SOCBoardLayout2 BOARDLAYOUT2}.
  *<P>

--- a/src/main/java/soc/message/SOCBoardLayout2.java
+++ b/src/main/java/soc/message/SOCBoardLayout2.java
@@ -25,9 +25,7 @@ import java.util.Hashtable;
 import java.util.Map;
 import java.util.StringTokenizer;
 
-import soc.game.SOCBoard;
-import soc.game.SOCBoardLarge;  // for javadocs
-import soc.game.SOCScenario;    // for javadocs
+import soc.game.*;
 
 
 /**
@@ -176,7 +174,7 @@ public class SOCBoardLayout2 extends SOCMessage
 
     /**
      * Create a SOCBoardLayout2 message for encoding format v1 or v2; see class javadoc for parameters' meanings.
-     * ({@link SOCBoard#BOARD_ENCODING_ORIGINAL} or {@link SOCBoard#BOARD_ENCODING_6PLAYER}.)
+     * ({@link Standard4p#BOARD_ENCODING_ORIGINAL} or {@link Standard6p#BOARD_ENCODING_6PLAYER}.)
      *
      * @param ga   the name of the game
      * @param bef  the board encoding format number, from {@link SOCBoard#getBoardEncodingFormat()}
@@ -220,7 +218,7 @@ public class SOCBoardLayout2 extends SOCMessage
 
     /**
      * Create a SOCBoardLayout2 message for encoding format v3.
-     * ({@link SOCBoardLarge}, {@link SOCBoard#BOARD_ENCODING_LARGE}.)
+     * ({@link SOCBoardLarge}, {@link SOCBoardLarge#BOARD_ENCODING_LARGE}.)
      *
      * @param ga   the name of the game
      * @param bef  the board encoding format number, from {@link SOCBoard#getBoardEncodingFormat()}

--- a/src/main/java/soc/robot/OpeningBuildStrategy.java
+++ b/src/main/java/soc/robot/OpeningBuildStrategy.java
@@ -903,7 +903,9 @@ public class OpeningBuildStrategy {
             resourceEstimates[0] = 0;
 
             // look at each hex
-            if (board.getBoardEncodingFormat() <= SOCBoard.BOARD_ENCODING_6PLAYER)
+            int bef = board.getBoardEncodingFormat();
+            if (bef == Standard6p.BOARD_ENCODING_6PLAYER ||
+                bef == Standard4p.BOARD_ENCODING_ORIGINAL)
             {
                 // v1 or v2 encoding
                 final int L = board.getNumberLayout().length;

--- a/src/main/java/soc/server/SOCBoardLargeAtServer.java
+++ b/src/main/java/soc/server/SOCBoardLargeAtServer.java
@@ -32,18 +32,7 @@ import java.util.Map;
 import java.util.Stack;
 import java.util.Vector;
 
-import soc.game.SOCBoard;
-import soc.game.SOCBoardLarge;
-import soc.game.SOCDevCardConstants;
-import soc.game.SOCFortress;
-import soc.game.SOCGame;
-import soc.game.SOCGameOption;
-import soc.game.SOCPlayer;
-import soc.game.SOCScenario;
-import soc.game.SOCSettlement;
-import soc.game.SOCShip;
-import soc.game.SOCVillage;
-import soc.game.SOCBoard.BoardFactory;
+import soc.game.*;
 import soc.util.IntPair;
 import soc.util.IntTriple;
 
@@ -55,7 +44,7 @@ import soc.util.IntTriple;
  *<P>
  * Sea board layout: A representation of a larger (up to 127 x 127 hexes) JSettlers board,
  * with an arbitrary mix of land and water tiles.
- * Implements {@link SOCBoard#BOARD_ENCODING_LARGE}.
+ * Implements {@link SOCBoardLarge#BOARD_ENCODING_LARGE}.
  * Activated with {@link SOCGameOption} {@code "SBL"}.
  *<P>
  * A {@link SOCGame} uses this board; the board is not given a reference to the game, to enforce layering
@@ -586,9 +575,9 @@ public class SOCBoardLargeAtServer extends SOCBoardLarge
 
             // - Mainland:
             makeNewBoard_placeHexes
-                ((maxPl > 4) ? makeNewBoard_landHexTypes_v2 : makeNewBoard_landHexTypes_v1,
+                ((maxPl > 4) ? Standard6p.makeNewBoard_landHexTypes_v2 : Standard4p.makeNewBoard_landHexTypes_v1,
                  (maxPl > 4) ? LANDHEX_DICEPATH_MAINLAND_6PL : LANDHEX_DICEPATH_MAINLAND_4PL,
-                 (maxPl > 4) ? makeNewBoard_diceNums_v2 : makeNewBoard_diceNums_v1,
+                 (maxPl > 4) ? Standard6p.makeNewBoard_diceNums_v2 : Standard4p.makeNewBoard_diceNums_v1,
                  false, true, 1, false, maxPl, opt_breakClumps, scen);
 
             // - Outlying islands:
@@ -600,7 +589,7 @@ public class SOCBoardLargeAtServer extends SOCBoardLarge
                  (maxPl > 4) ? LANDHEX_LANDAREA_RANGES_ISLANDS_6PL : LANDHEX_LANDAREA_RANGES_ISLANDS_4PL,
                  false, maxPl, null, scen);
 
-            PORTS_TYPES_MAINLAND = (maxPl > 4) ? PORTS_TYPE_V2 : PORTS_TYPE_V1;
+            PORTS_TYPES_MAINLAND = (maxPl > 4) ? Standard6p.PORTS_TYPE_V2 : Standard4p.PORTS_TYPE_V1;
             PORTS_TYPES_ISLANDS = (maxPl > 4) ? PORT_TYPE_ISLANDS_6PL : PORT_TYPE_ISLANDS_4PL;
             PORT_LOC_FACING_MAINLAND = (maxPl > 4) ? PORT_EDGE_FACING_MAINLAND_6PL : PORT_EDGE_FACING_MAINLAND_4PL;
             PORT_LOC_FACING_ISLANDS = (maxPl > 4) ? PORT_EDGE_FACING_ISLANDS_6PL : PORT_EDGE_FACING_ISLANDS_4PL;
@@ -2572,7 +2561,7 @@ public class SOCBoardLargeAtServer extends SOCBoardLarge
 
     /**
      * Port types for the 4 outlying-island ports on the 4-player fallback board.
-     * For the mainland's port types, use {@link SOCBoard#PORTS_TYPE_V1}.
+     * For the mainland's port types, use {@link Standard4p#PORTS_TYPE_V1}.
      */
     private static final int PORT_TYPE_ISLANDS_4PL[] =
     {
@@ -2583,7 +2572,7 @@ public class SOCBoardLargeAtServer extends SOCBoardLarge
      * Fallback board layout for 4 players: Dice-number path (hex coordinates)
      * on the main island, spiraling inward from the shore.
      * The outlying islands have no dice path.
-     * For the mainland's dice numbers, see {@link SOCBoard#makeNewBoard_diceNums_v1}.
+     * For the mainland's dice numbers, see {@link Standard4p#makeNewBoard_diceNums_v1}.
      * @see #LANDHEX_COORD_MAINLAND
      */
     private static final int LANDHEX_DICEPATH_MAINLAND_4PL[] =
@@ -2652,7 +2641,7 @@ public class SOCBoardLargeAtServer extends SOCBoardLarge
 
     /**
      * Fallback board layout, 4 players: Land hex types for the 3 small islands,
-     * to be used with (for the main island) {@link #makeNewBoard_landHexTypes_v1}[].
+     * to be used with (for the main island) {@link Standard4p#makeNewBoard_landHexTypes_v1}[].
      */
     private static final int LANDHEX_TYPE_ISLANDS_4PL[] =
     {
@@ -2678,7 +2667,7 @@ public class SOCBoardLargeAtServer extends SOCBoardLarge
      * Fallback board layout for 6 players: Dice-number path (hex coordinates)
      * on the main island, spiraling inward from the shore.
      * The outlying islands have no dice path.
-     * For the mainland's dice numbers, see {@link SOCBoard#makeNewBoard_diceNums_v2}.
+     * For the mainland's dice numbers, see {@link Standard6p#makeNewBoard_diceNums_v2}.
      */
     private static final int LANDHEX_DICEPATH_MAINLAND_6PL[] =
     {
@@ -2738,7 +2727,7 @@ public class SOCBoardLargeAtServer extends SOCBoardLarge
 
     /**
      * Fallback board layout, 6 players: Land hex types for the 3 small islands,
-     * to be used with (for the main island) {@link #makeNewBoard_landHexTypes_v2}[].
+     * to be used with (for the main island) {@link Standard6p#makeNewBoard_landHexTypes_v2}[].
      */
     private static final int LANDHEX_TYPE_ISLANDS_6PL[] =
     {
@@ -2774,7 +2763,7 @@ public class SOCBoardLargeAtServer extends SOCBoardLarge
 
     /**
      * Port types for the 4 outlying-island ports on the 6-player fallback board.
-     * For the mainland's port types, use {@link SOCBoard#PORTS_TYPE_V2}.
+     * For the mainland's port types, use {@link Standard6p#PORTS_TYPE_V2}.
      */
     private static final int PORT_TYPE_ISLANDS_6PL[] =
     {
@@ -2813,8 +2802,8 @@ public class SOCBoardLargeAtServer extends SOCBoardLarge
             CLAY_HEX, CLAY_HEX, ORE_HEX, ORE_HEX, SHEEP_HEX, SHEEP_HEX, SHEEP_HEX, SHEEP_HEX,
             WHEAT_HEX, WHEAT_HEX, WHEAT_HEX, WOOD_HEX, WOOD_HEX, WOOD_HEX
         },
-        SOCBoard.makeNewBoard_landHexTypes_v1,  // 4 players
-        SOCBoard.makeNewBoard_landHexTypes_v2   // 6 players
+        Standard4p.makeNewBoard_landHexTypes_v1,  // 4 players
+        Standard6p.makeNewBoard_landHexTypes_v2   // 6 players
     };
 
     /**
@@ -2852,8 +2841,8 @@ public class SOCBoardLargeAtServer extends SOCBoardLarge
     private static final int NSHO_DICENUM_MAIN[][] =
     {
         { 2, 3, 4, 5, 5, 6, 6, 8, 8, 9, 10, 10, 11, 11 },  // 3 players
-        SOCBoard.makeNewBoard_diceNums_v1,  // 4 players
-        SOCBoard.makeNewBoard_diceNums_v2   // 6 players
+        Standard4p.makeNewBoard_diceNums_v1,  // 4 players
+        Standard6p.makeNewBoard_diceNums_v2   // 6 players
     };
 
     /**
@@ -2885,8 +2874,8 @@ public class SOCBoardLargeAtServer extends SOCBoardLarge
     private static final int NSHO_PORT_TYPE[][] =
     {
         { 0, 0, 0, CLAY_PORT, ORE_PORT, SHEEP_PORT, WHEAT_PORT, WOOD_PORT },  // 3 players
-        SOCBoard.PORTS_TYPE_V1,  // 4 players
-        SOCBoard.PORTS_TYPE_V2   // 6 players
+        Standard4p.PORTS_TYPE_V1,  // 4 players
+        Standard6p.PORTS_TYPE_V2   // 6 players
     };
 
     /** New Shores: Land hex types on the several small islands. Shuffled. */
@@ -4687,7 +4676,8 @@ public class SOCBoardLargeAtServer extends SOCBoardLarge
         {
             if (! largeBoard)
             {
-                return SOCBoard.DefaultBoardFactory.staticCreateBoard(gameOpts, false, maxPlayers);
+                DefaultBoardFactory factory = new DefaultBoardFactory();
+                return factory.createBoard(gameOpts, false, maxPlayers);
             } else {
                 // Check board size, set _BHW if not default.
                 final int boardHeightWidth = getBoardSize(gameOpts, maxPlayers);

--- a/src/main/java/soc/server/SOCGameHandler.java
+++ b/src/main/java/soc/server/SOCGameHandler.java
@@ -2708,9 +2708,9 @@ public class SOCGameHandler extends GameHandler
 
         board = ga.getBoard();
         final int bef = board.getBoardEncodingFormat();
-        if (bef <= SOCBoard.BOARD_ENCODING_6PLAYER)
+        if (bef == Standard6p.BOARD_ENCODING_6PLAYER ||
+            bef == Standard4p.BOARD_ENCODING_ORIGINAL)
         {
-            // v1 or v2
             hexes = board.getHexLayout();
             numbers = board.getNumberLayout();
         } else {
@@ -2726,12 +2726,12 @@ public class SOCGameHandler extends GameHandler
         }
         switch (bef)
         {
-        case SOCBoard.BOARD_ENCODING_ORIGINAL: // v1
+        case Standard4p.BOARD_ENCODING_ORIGINAL: // v1
             // fall through to v2
-        case SOCBoard.BOARD_ENCODING_6PLAYER:  // v2
+        case Standard6p.BOARD_ENCODING_6PLAYER:  // v2
             return new SOCBoardLayout2(ga.getName(), bef, hexes, numbers, board.getPortsLayout(), robber);
 
-        case SOCBoard.BOARD_ENCODING_LARGE:  // v3
+        case SOCBoardLarge.BOARD_ENCODING_LARGE:  // v3
             final SOCBoardLarge bl = (SOCBoardLarge) board;
             return new SOCBoardLayout2
                 (ga.getName(), bef, bl.getLandHexLayout(), board.getPortsLayout(),


### PR DESCRIPTION
SOCBoard is a ["God-class"](https://en.wikipedia.org/wiki/God_object). It knows too much about different types of boards and it does too much. Furthermore, there's a lot of unnecessary complexity. 

This PR tries to move responsibilities into different classes: Standard4p and Standard6p. This can be considered a first step into breaking down complexity. The next step is to remove magic numbers and/or move grid logic into vertex/edge/location classes.

I set the target branch to v3, so v1/v2 is not affected.

- Introduce Standard4p & Standard6p (I anticipate on creating `soc.game.board` package, so no prefix or suffix is needed
- SOCBoard now abstract
- Move XXX_V1 into Standard4p and XXX_V2 into Standard6p
- Remove static factory method on DefaultBoardFactory
-Change implementation of factory to cater to new classes
- Remove boardEncodingFormat field, transition into getBoardEncodingFormat() and have it implemented by the derived classes
- `Vector<Integer> variable = new Vector<Integer>()` simplified into `Vector<Integer> variable = new Vector<>()`
- **Note that setBoardEncodingFormat call is removed! I'm not too sure if this can be done. Would you mind to check this?**