### PR TITLE
update the version of java to v1.6 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ version = '2.0.00'  // same as in src/main/resources/resources/version.info
 mainClassName = "soc.client.SOCPlayerClient"
 
 compileJava {
-    sourceCompatibility = '1.5'
-    targetCompatibility = '1.5'
+    sourceCompatibility = '1.6'
+    targetCompatibility = '1.6'
 }
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/net/nand/util/i18n/gui/PropertiesTranslatorEditor.java
+++ b/src/main/java/net/nand/util/i18n/gui/PropertiesTranslatorEditor.java
@@ -377,7 +377,7 @@ public class PropertiesTranslatorEditor
         {
             SecurityManager sm = System.getSecurityManager();
             if (sm != null)
-                sm.checkSystemClipboardAccess();
+                sm.checkPermission(new java.awt.AWTPermission("accessClipboard"));
         } catch (SecurityException e) {
             canSetClipboard = false;
         }


### PR DESCRIPTION
unless there is a reason to keep java 5 in there? and fix a method that was deprecated in java 8 and removed in java 9.

(Alternatively, I could have adjusted my machine, but Java 5 is no longer support by Oracle.)