### PR TITLE
The Integer constructor has been deprecated in later versions of Java.

### DIFF
--- a/src/main/java/soc/client/NewGameOptionsFrame.java
+++ b/src/main/java/soc/client/NewGameOptionsFrame.java
@@ -1683,7 +1683,7 @@ import soc.util.Version;
             if (validChange)
             {
                 if (otypeIsInt)
-                    fireOptionChangeListener(cl, opt, new Integer(oldIntValue), new Integer(opt.getIntValue()));
+                    fireOptionChangeListener(cl, opt, Integer.valueOf(oldIntValue), Integer.valueOf(opt.getIntValue()));
                 else
                     fireOptionChangeListener(cl, opt, oldText, newText);
             }
@@ -1792,8 +1792,8 @@ import soc.util.Version;
             if (chIdx != -1)
             {
                 final int nv = chIdx + opt.minIntValue;
-                Integer newValue = new Integer(nv);
-                Integer oldValue = new Integer(opt.getIntValue());
+                Integer newValue = Integer.valueOf(nv);
+                Integer oldValue = Integer.valueOf(opt.getIntValue());
                 opt.setIntValue(nv);
                 if (fireBooleanListener)
                     fireOptionChangeListener(cl, opt, boolOldValue, boolNewValue);

--- a/src/main/java/soc/client/SOCBoardPanel.java
+++ b/src/main/java/soc/client/SOCBoardPanel.java
@@ -4498,7 +4498,7 @@ import java.util.Timer;
                     final int hexCoord = rshift | c;
                     final int hexType = (r < bh) ? board.getHexTypeFromCoord(hexCoord) : SOCBoard.WATER_HEX;
                     drawHex(g, x, y, hexType, -1, hexCoord);
-                    if ((landHexShow != null) && landHexShow.contains(new Integer(hexCoord)))
+                    if ((landHexShow != null) && landHexShow.contains(Integer.valueOf(hexCoord)))
                     {
                        g.setColor(Color.RED);
                        g.drawRoundRect

--- a/src/main/java/soc/game/SOCBoard.java
+++ b/src/main/java/soc/game/SOCBoard.java
@@ -807,31 +807,31 @@ public abstract class SOCBoard implements Serializable, Cloneable
         if (is6player)
         {
             for (i = 0x07; i <= 0x6D; i += 0x11)
-                nodesOnLand.add(new Integer(i));
+                nodesOnLand.add(Integer.valueOf(i));
         }
 
         for (i = 0x27 - westAdj; i <= 0x8D; i += 0x11)  //  Northernmost horizontal row: each north corner across 3 hexes
-            nodesOnLand.add(new Integer(i));
+            nodesOnLand.add(Integer.valueOf(i));
 
         for (i = 0x25 - westAdj; i <= 0xAD; i += 0x11)  // Next: each north corner of row of 4 / south corner of the northernmost 3 hexes
-            nodesOnLand.add(new Integer(i));
+            nodesOnLand.add(Integer.valueOf(i));
 
         for (i = 0x23 - westAdj; i <= 0xCD; i += 0x11)  // Next: north corners of middle row of 5 hexes
-            nodesOnLand.add(new Integer(i));
+            nodesOnLand.add(Integer.valueOf(i));
 
         for (i = 0x32 - westAdj; i <= 0xDC; i += 0x11) // Next: south corners of middle row of 5 hexes
-            nodesOnLand.add(new Integer(i));
+            nodesOnLand.add(Integer.valueOf(i));
 
         for (i = 0x52 - westAdj; i <= 0xDA; i += 0x11)  // South corners of row of 4 / north corners of the southernmost 3 hexes
-            nodesOnLand.add(new Integer(i));
+            nodesOnLand.add(Integer.valueOf(i));
 
         for (i = 0x72 - westAdj; i <= 0xD8; i += 0x11)  // Southernmost horizontal row: each south corner across 3 hexes
-            nodesOnLand.add(new Integer(i));
+            nodesOnLand.add(Integer.valueOf(i));
 
         if (is6player)
         {
             for (i = 0x70; i <= 0xD6; i += 0x11)
-                nodesOnLand.add(new Integer(i));
+                nodesOnLand.add(Integer.valueOf(i));
         }
     }
 
@@ -986,7 +986,7 @@ public abstract class SOCBoard implements Serializable, Cloneable
                 Vector<Integer> unvisited = new Vector<Integer>();  // contains each land hex's coordinate
                 for (int i = 0; i < landHex.length; ++i)
                 {
-                    unvisited.addElement(new Integer(numToHexID[numPath[i]]));
+                    unvisited.addElement(Integer.valueOf(numToHexID[numPath[i]]));
                 }
                 clumpsNotOK = makeNewBoard_checkLandHexResourceClumps(unvisited, clumpSize);
             }  // if (checkClumps)
@@ -1080,7 +1080,7 @@ public abstract class SOCBoard implements Serializable, Cloneable
         //   We're operating on Integer instances, which is okay because
         //   vector methods such as contains() and remove() test obj.equals()
         //   to determine if the Integer is a member.
-        //   (getAdjacent() returns new Integer objs with the same value
+        //   (getAdjacent() returns Integer.valueOf objs with the same value
         //    as unvisited's members.)
 
         boolean clumpsNotOK = false;    // will set true in while-loop body
@@ -1308,9 +1308,9 @@ public abstract class SOCBoard implements Serializable, Cloneable
             }
         }
 
-        final Integer node1Int = new Integer(node1),
-                      node2Int = new Integer(node2),
-                      ptypeInt = new Integer(ptype);
+        final Integer node1Int = Integer.valueOf(node1),
+                      node2Int = Integer.valueOf(node2),
+                      ptypeInt = Integer.valueOf(ptype);
 
         nodeIDtoPortType.put(node1Int, ptypeInt);
         nodeIDtoPortType.put(node2Int, ptypeInt);
@@ -1349,52 +1349,52 @@ public abstract class SOCBoard implements Serializable, Cloneable
         if (is6player)
         {
             for (i = 0x07; i <= 0x5C; i += 0x11)
-                legalRoads.add(new Integer(i));
+                legalRoads.add(Integer.valueOf(i));
 
             for (i = 0x06; i <= 0x6C; i += 0x22)
-                legalRoads.add(new Integer(i));
+                legalRoads.add(Integer.valueOf(i));
         }
 
         for (i = 0x27 - westAdj; i <= 0x7C; i += 0x11)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(Integer.valueOf(i));
 
         for (i = 0x26 - westAdj; i <= 0x8C; i += 0x22)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(Integer.valueOf(i));
 
         for (i = 0x25 - westAdj; i <= 0x9C; i += 0x11)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(Integer.valueOf(i));
 
         for (i = 0x24 - westAdj; i <= 0xAC; i += 0x22)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(Integer.valueOf(i));
 
         for (i = 0x23 - westAdj; i <= 0xBC; i += 0x11)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(Integer.valueOf(i));
 
         for (i = 0x22 - westAdj; i <= 0xCC; i += 0x22)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(Integer.valueOf(i));
 
         for (i = 0x32 - westAdj; i <= 0xCB; i += 0x11)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(Integer.valueOf(i));
 
         for (i = 0x42 - westAdj; i <= 0xCA; i += 0x22)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(Integer.valueOf(i));
 
         for (i = 0x52 - westAdj; i <= 0xC9; i += 0x11)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(Integer.valueOf(i));
 
         for (i = 0x62 - westAdj; i <= 0xC8; i += 0x22)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(Integer.valueOf(i));
 
         for (i = 0x72 - westAdj; i <= 0xC7; i += 0x11)
-            legalRoads.add(new Integer(i));
+            legalRoads.add(Integer.valueOf(i));
 
         if (is6player)
         {
             for (i = 0x60; i <= 0xC6; i += 0x22)
-                legalRoads.add(new Integer(i));
+                legalRoads.add(Integer.valueOf(i));
 
             for (i = 0x70; i <= 0xC5; i += 0x11)
-                legalRoads.add(new Integer(i));
+                legalRoads.add(Integer.valueOf(i));
         }
 
         return legalRoads;
@@ -1758,7 +1758,7 @@ public abstract class SOCBoard implements Serializable, Cloneable
         if ((nodeCoord < 0) || (nodeIDtoPortType == null))
             return -1;
 
-        Integer ptype = nodeIDtoPortType.get(new Integer(nodeCoord));
+        Integer ptype = nodeIDtoPortType.get(Integer.valueOf(nodeCoord));
         if (ptype != null)
             return ptype.intValue();
         else
@@ -2102,9 +2102,9 @@ public abstract class SOCBoard implements Serializable, Cloneable
         Vector<Integer> nodes = new Vector<Integer>(2);
         final int[] narr = getAdjacentNodesToEdge_arr(coord);
         if ((narr[0] >= minNode) && (narr[0] <= MAXNODE))
-            nodes.addElement(new Integer(narr[0]));
+            nodes.addElement(Integer.valueOf(narr[0]));
         if ((narr[1] >= minNode) && (narr[1] <= MAXNODE))
-            nodes.addElement(new Integer(narr[1]));
+            nodes.addElement(Integer.valueOf(narr[1]));
         return nodes;
     }
 
@@ -2181,28 +2181,28 @@ public abstract class SOCBoard implements Serializable, Cloneable
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(Integer.valueOf(tmp));
             }
 
             tmp = coord + 0x01;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(Integer.valueOf(tmp));
             }
 
             tmp = coord + 0x10;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(Integer.valueOf(tmp));
             }
 
             tmp = coord - 0x01;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(Integer.valueOf(tmp));
             }
         }
 
@@ -2216,28 +2216,28 @@ public abstract class SOCBoard implements Serializable, Cloneable
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(Integer.valueOf(tmp));
             }
 
             tmp = coord + 0x01;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(Integer.valueOf(tmp));
             }
 
             tmp = coord + 0x11;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(Integer.valueOf(tmp));
             }
 
             tmp = coord - 0x01;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(Integer.valueOf(tmp));
             }
         }
         else
@@ -2250,28 +2250,28 @@ public abstract class SOCBoard implements Serializable, Cloneable
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(Integer.valueOf(tmp));
             }
 
             tmp = coord + 0x11;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(Integer.valueOf(tmp));
             }
 
             tmp = coord + 0x10;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(Integer.valueOf(tmp));
             }
 
             tmp = coord - 0x11;
 
             if ((tmp >= minEdge) && (tmp <= maxEdge))
             {
-                edges.addElement(new Integer(tmp));
+                edges.addElement(Integer.valueOf(tmp));
             }
         }
 
@@ -2299,21 +2299,21 @@ public abstract class SOCBoard implements Serializable, Cloneable
 
             if ((tmp >= MINHEX) && (tmp <= MAXHEX))
             {
-                hexes.addElement(new Integer(tmp));
+                hexes.addElement(Integer.valueOf(tmp));
             }
 
             tmp = coord + 0x10;
 
             if ((tmp >= MINHEX) && (tmp <= MAXHEX))
             {
-                hexes.addElement(new Integer(tmp));
+                hexes.addElement(Integer.valueOf(tmp));
             }
 
             tmp = coord - 0x12;
 
             if ((tmp >= MINHEX) && (tmp <= MAXHEX))
             {
-                hexes.addElement(new Integer(tmp));
+                hexes.addElement(Integer.valueOf(tmp));
             }
         }
         else
@@ -2326,21 +2326,21 @@ public abstract class SOCBoard implements Serializable, Cloneable
 
             if ((tmp >= MINHEX) && (tmp <= MAXHEX))
             {
-                hexes.addElement(new Integer(tmp));
+                hexes.addElement(Integer.valueOf(tmp));
             }
 
             tmp = coord + 0x01;
 
             if ((tmp >= MINHEX) && (tmp <= MAXHEX))
             {
-                hexes.addElement(new Integer(tmp));
+                hexes.addElement(Integer.valueOf(tmp));
             }
 
             tmp = coord - 0x01;
 
             if ((tmp >= MINHEX) && (tmp <= MAXHEX))
             {
-                hexes.addElement(new Integer(tmp));
+                hexes.addElement(Integer.valueOf(tmp));
             }
         }
 
@@ -2359,7 +2359,7 @@ public abstract class SOCBoard implements Serializable, Cloneable
         int[] edgea = getAdjacentEdgesToNode_arr(coord);
         for (int i = edgea.length - 1; i>=0; --i)
             if (edgea[i] != -9)
-                edges.addElement(new Integer(edgea[i]));
+                edges.addElement(Integer.valueOf(edgea[i]));
         return edges;
     }
 
@@ -2595,7 +2595,7 @@ public abstract class SOCBoard implements Serializable, Cloneable
         int[] nodea = getAdjacentNodesToNode_arr(coord);
         for (int i = nodea.length - 1; i>=0; --i)
             if (nodea[i] != -9)
-                nodes.addElement(new Integer(nodea[i]));
+                nodes.addElement(Integer.valueOf(nodea[i]));
         return nodes;
     }
 
@@ -2903,7 +2903,7 @@ public abstract class SOCBoard implements Serializable, Cloneable
             && (includeWater
                 || ((hexLayout[hexIDtoNum[hexCoord]] <= MAX_LAND_HEX)
                     && (hexLayout[hexIDtoNum[hexCoord]] != WATER_HEX)) ))
-            addTo.addElement(new Integer(hexCoord));
+            addTo.addElement(Integer.valueOf(hexCoord));
     }
 
     /**

--- a/src/main/java/soc/game/SOCBoardLarge.java
+++ b/src/main/java/soc/game/SOCBoardLarge.java
@@ -881,7 +881,7 @@ public class SOCBoardLarge extends SOCBoard
 
                     // OK to add
                     if (hasLand)
-                        legalRoadEdges.add(new Integer(edge));
+                        legalRoadEdges.add(Integer.valueOf(edge));
                         // it's ok to add if this set already contains an Integer equal to that edge.
                 }
             }
@@ -2548,7 +2548,7 @@ public class SOCBoardLarge extends SOCBoard
             || ((hexLayoutLg[r][c] <= MAX_LAND_HEX_LG)
                 && (hexLayoutLg[r][c] != WATER_HEX)) )
         {
-            addTo.addElement(new Integer((r << 8) | c));
+            addTo.addElement(Integer.valueOf((r << 8) | c));
         }
     }
 
@@ -2922,7 +2922,7 @@ public class SOCBoardLarge extends SOCBoard
             final int er = r + offs[i];  ++i;
             final int ec = c + offs[i];  ++i;
             if (isEdgeInBounds(er, ec))
-                edge.addElement(new Integer( (er << 8) | ec ));
+                edge.addElement(Integer.valueOf( (er << 8) | ec ));
         }
         return edge;
     }
@@ -3022,8 +3022,8 @@ public class SOCBoardLarge extends SOCBoard
     {
         Vector<Integer> nodes = new Vector<Integer>(2);
         final int[] narr = getAdjacentNodesToEdge_arr(coord);
-        nodes.addElement(new Integer(narr[0]));
-        nodes.addElement(new Integer(narr[1]));
+        nodes.addElement(Integer.valueOf(narr[0]));
+        nodes.addElement(Integer.valueOf(narr[1]));
         return nodes;
     }
 
@@ -3169,34 +3169,34 @@ public class SOCBoardLarge extends SOCBoard
         {
             // North: (r-1, c)
             if (r > 1)
-                hexes.addElement(new Integer(nodeCoord - 0x0100));
+                hexes.addElement(Integer.valueOf(nodeCoord - 0x0100));
 
             if (r < (boardHeight-1))
             {
                 // SW: (r+1, c-1)
                 if (c > 1)
-                    hexes.addElement(new Integer((nodeCoord + 0x0100) - 1));
+                    hexes.addElement(Integer.valueOf((nodeCoord + 0x0100) - 1));
 
                 // SE: (r+1, c+1)
                 if (c < (boardWidth-1))
-                    hexes.addElement(new Integer((nodeCoord + 0x0100) + 1));
+                    hexes.addElement(Integer.valueOf((nodeCoord + 0x0100) + 1));
             }
         }
         else
         {
             // South: (r+1, c)
             if (r < (boardHeight-1))
-                hexes.addElement(new Integer(nodeCoord + 0x0100));
+                hexes.addElement(Integer.valueOf(nodeCoord + 0x0100));
 
             if (r > 1)
             {
                 // NW: (r-1, c-1)
                 if (c > 1)
-                    hexes.addElement(new Integer((nodeCoord - 0x0100) - 1));
+                    hexes.addElement(Integer.valueOf((nodeCoord - 0x0100) - 1));
 
                 // NE: (r-1, c+1)
                 if (c < (boardWidth-1))
-                    hexes.addElement(new Integer((nodeCoord - 0x0100) + 1));
+                    hexes.addElement(Integer.valueOf((nodeCoord - 0x0100) + 1));
             }
         }
 

--- a/src/main/java/soc/game/SOCGame.java
+++ b/src/main/java/soc/game/SOCGame.java
@@ -3461,7 +3461,7 @@ public class SOCGame implements Serializable, Cloneable
          */
         if (pp.getType() == SOCPlayingPiece.SHIP)
         {
-            placedShipsThisTurn.add(new Integer(coord));
+            placedShipsThisTurn.add(Integer.valueOf(coord));
         }
 
         /**
@@ -3527,7 +3527,7 @@ public class SOCGame implements Serializable, Cloneable
 
                 if (scenarioEventListener != null)
                     scenarioEventListener.gameEvent
-                        (this, SOCScenarioGameEvent.SGE_FOG_HEX_REVEALED, new Integer(hexCoord));
+                        (this, SOCScenarioGameEvent.SGE_FOG_HEX_REVEALED, Integer.valueOf(hexCoord));
 
                 if (! initialSettlement)
                     break;
@@ -3866,7 +3866,7 @@ public class SOCGame implements Serializable, Cloneable
     {
         if (movedShipThisTurn || ! (hasSeaBoard && (currentPlayerNumber == pn) && (gameState == PLAY1)))
             return null;
-        if (placedShipsThisTurn.contains(new Integer(fromEdge)))
+        if (placedShipsThisTurn.contains(Integer.valueOf(fromEdge)))
             return null;
 
         // check fromEdge vs. pirate hex
@@ -5029,7 +5029,7 @@ public class SOCGame implements Serializable, Cloneable
                     final int num = fromHand.getAmount(rsrcType);
                     if (num == lowestNum)
                     {
-                        tempHand.addElement(new Integer(rsrcType));
+                        tempHand.addElement(Integer.valueOf(rsrcType));
                         --toAdd;  // might go below 0, that's okay: we'll shuffle.
                     }
                     else if (num < lowestNum)

--- a/src/main/java/soc/game/SOCPlayer.java
+++ b/src/main/java/soc/game/SOCPlayer.java
@@ -386,7 +386,7 @@ public class SOCPlayer implements SOCDevCardConstants, Serializable, Cloneable
      * Placing a settlement will clear its node and adjacent nodes.
      *<P>
      * Key = node coordinate, as {@link Integer}.
-     * If {@link HashSet#contains(Object) legalSettlements.contains(new Integer(nodeCoord))},
+     * If {@link HashSet#contains(Object) legalSettlements.contains(Integer.valueOf(nodeCoord))},
      * then <tt>nodeCoord</tt> is a legal settlement.
      *<P>
      * If not {@link SOCGame#hasSeaBoard}, initialized in constructor
@@ -454,7 +454,7 @@ public class SOCPlayer implements SOCDevCardConstants, Serializable, Cloneable
      * Placing a settlement will clear its node and adjacent nodes.
      *<P>
      * Key = node coordinate, as {@link Integer}.
-     * If {@link HashSet#contains(Object) potentialSettlements.contains(new Integer(nodeCoord))},
+     * If {@link HashSet#contains(Object) potentialSettlements.contains(Integer.valueOf(nodeCoord))},
      * then this is a potential settlement.
      * @see #legalSettlements
      * @see #setPotentialAndLegalSettlements(Collection, boolean, HashSet[])
@@ -1833,7 +1833,7 @@ public class SOCPlayer implements SOCDevCardConstants, Serializable, Cloneable
             // - node is the "far end" of edge, next to be inspected
             // - segment's most recently added ship is the one at edge
 
-            final Integer edgeInt = new Integer(edge);
+            final Integer edgeInt = Integer.valueOf(edge);
 
             // have we already visited this edge?
             if (alreadyVisited.contains(edgeInt))
@@ -1930,7 +1930,7 @@ public class SOCPlayer implements SOCDevCardConstants, Serializable, Cloneable
                 {
                     // Build an encounteredSelf list entry.
                     Vector<Object> already = new Vector<Object>();
-                    already.add(new Integer(node));
+                    already.add(Integer.valueOf(node));
                     already.addAll(segment);
 
                     encounteredSelf.add(already);
@@ -2713,8 +2713,8 @@ public class SOCPlayer implements SOCDevCardConstants, Serializable, Cloneable
         {
             final int node0 = nodeCoords[0],
                       node1 = nodeCoords[1];
-            final Integer node0Int = new Integer(node0),
-                          node1Int = new Integer(node1);
+            final Integer node0Int = Integer.valueOf(node0),
+                          node1Int = Integer.valueOf(node1);
 
             // roadNodeGraph[node0][node1]
             int[] rnArr = roadNodeGraph.get(node0Int);
@@ -3002,7 +3002,7 @@ public class SOCPlayer implements SOCDevCardConstants, Serializable, Cloneable
     {
         final boolean ours = (piece.getPlayerNumber() == playerNumber);
         final int pieceCoord = piece.getCoordinates();
-        final Integer pieceCoordInt = new Integer(pieceCoord);
+        final Integer pieceCoordInt = Integer.valueOf(pieceCoord);
 
         final SOCBoard board = game.getBoard();
         switch (piece.getType())
@@ -3136,7 +3136,7 @@ public class SOCPlayer implements SOCDevCardConstants, Serializable, Cloneable
      */
     protected void undoPutPieceAuxSettlement(int settlementNode)
     {
-        final Integer settleNodeInt = new Integer(settlementNode);
+        final Integer settleNodeInt = Integer.valueOf(settlementNode);
 
         //D.ebugPrintln("))))) undoPutPieceAuxSettlement : node = "+Integer.toHexString(settlementNode));
         //
@@ -3282,7 +3282,7 @@ public class SOCPlayer implements SOCDevCardConstants, Serializable, Cloneable
         D.ebugPrintln("--- SOCPlayer.removePiece(" + piece + ")");
 
         final int pieceCoord = piece.getCoordinates();
-        final Integer pieceCoordInt = new Integer(pieceCoord);
+        final Integer pieceCoordInt = Integer.valueOf(pieceCoord);
         final int ptype = piece.getType();
 
         Enumeration<SOCPlayingPiece> pEnum = pieces.elements();
@@ -3375,8 +3375,8 @@ public class SOCPlayer implements SOCDevCardConstants, Serializable, Cloneable
                     {
                         final int node0 = edgeNodeCoords[0],
                                   node1 = edgeNodeCoords[1];
-                        final Integer node0Int = new Integer(node0),
-                                      node1Int = new Integer(node1);
+                        final Integer node0Int = Integer.valueOf(node0),
+                                      node1Int = Integer.valueOf(node1);
 
                         // check roadNodeGraph[node0][node1]
                         int[] rnArr = roadNodeGraph.get(node0Int);
@@ -3704,7 +3704,7 @@ public class SOCPlayer implements SOCDevCardConstants, Serializable, Cloneable
         final boolean ours;
         boolean blocked;
         final int id = piece.getCoordinates();
-        final Integer idInt = new Integer(id);
+        final Integer idInt = Integer.valueOf(id);
         SOCBoard board = game.getBoard();
 
         /**
@@ -3759,7 +3759,7 @@ public class SOCPlayer implements SOCDevCardConstants, Serializable, Cloneable
                             int edge = edges[i];
                             if (edge != -9)
                             {
-                                final Integer edgeInt = new Integer(edge);
+                                final Integer edgeInt = Integer.valueOf(edge);
                                 if (ptype == SOCPlayingPiece.ROAD)
                                 {
                                     if (legalRoads.contains(edgeInt))
@@ -3771,7 +3771,7 @@ public class SOCPlayer implements SOCDevCardConstants, Serializable, Cloneable
                             }
                         }
 
-                        final Integer nodeInt = new Integer(node);
+                        final Integer nodeInt = Integer.valueOf(node);
                         if (legalSettlements.contains(nodeInt))
                         {
                             potentialSettlements.add(nodeInt);
@@ -3837,7 +3837,7 @@ public class SOCPlayer implements SOCDevCardConstants, Serializable, Cloneable
             {
                 if (adjac[i] != -9)
                 {
-                    final Integer adjacNodeInt = new Integer(adjac[i]);
+                    final Integer adjacNodeInt = Integer.valueOf(adjac[i]);
                     potentialSettlements.remove(adjacNodeInt);
                     legalSettlements.remove(adjacNodeInt);
                 }
@@ -3856,7 +3856,7 @@ public class SOCPlayer implements SOCDevCardConstants, Serializable, Cloneable
                     tmp = adjac[i];
                     if (tmp != -9)
                     {
-                        final Integer tmpEdgeInt = new Integer(tmp);
+                        final Integer tmpEdgeInt = Integer.valueOf(tmp);
                         if (legalRoads.contains(tmpEdgeInt))
                             potentialRoads.add(tmpEdgeInt);
                         if (legalShips.contains(tmpEdgeInt))

--- a/src/main/java/soc/game/SOCPlayerNumbers.java
+++ b/src/main/java/soc/game/SOCPlayerNumbers.java
@@ -181,7 +181,7 @@ public class SOCPlayerNumbers
         //    So, skip this loop:
         // for (int i = 0; i < landHexCoords.length; i++)
         // {
-        //    numberAndResourceForHex.put(new Integer(landHexCoords[i]), new Vector());
+        //    numberAndResourceForHex.put(Integer.valueOf(landHexCoords[i]), new Vector());
         // }
     }
 
@@ -397,7 +397,7 @@ public class SOCPlayerNumbers
             if (landHexCoords[i] == robberHex)
                 continue;
 
-            Vector<IntPair> pairs = numberAndResourceForHex.get(new Integer(landHexCoords[i]));
+            Vector<IntPair> pairs = numberAndResourceForHex.get(Integer.valueOf(landHexCoords[i]));
             if (pairs == null)
                 continue;
 
@@ -456,9 +456,9 @@ public class SOCPlayerNumbers
                     if (hasSeaBoard && (res == SOCBoardLarge.GOLD_HEX))
                     {
                         for (int r = SOCResourceConstants.CLAY; r <= SOCResourceConstants.WOOD; ++r)
-                            resources.addElement(new Integer(r));
+                            resources.addElement(Integer.valueOf(r));
                     } else {
-                        resources.addElement(new Integer(res));
+                        resources.addElement(Integer.valueOf(res));
                     }
                 }
             }
@@ -481,9 +481,9 @@ public class SOCPlayerNumbers
     {
         if ((resource >= SOCResourceConstants.CLAY) && (resource <= SOCResourceConstants.WOOD))
         {
-            numbersForResource[resource].addElement(new Integer(diceNum));
+            numbersForResource[resource].addElement(Integer.valueOf(diceNum));
 
-            Integer resourceInt = new Integer(resource);
+            Integer resourceInt = Integer.valueOf(resource);
 
             //if (!resourcesForNumber[number].contains(resourceInt)) {
             resourcesForNumber[diceNum].addElement(resourceInt);
@@ -498,17 +498,17 @@ public class SOCPlayerNumbers
             }
 
             // GOLD_HEX: Add all 5 resource types
-            final Integer diceNumInt = new Integer(diceNum);
+            final Integer diceNumInt = Integer.valueOf(diceNum);
             for (int res = SOCResourceConstants.CLAY; res <= SOCResourceConstants.WOOD; ++res)
             {
                 numbersForResource[res].addElement(diceNumInt);
-                resourcesForNumber[diceNum].addElement(new Integer(res));
+                resourcesForNumber[diceNum].addElement(Integer.valueOf(res));
             }
 
             // GOLD_HEX is okay in numberAndResourceForHex.
         }
 
-        final Integer hexInt = new Integer(hex);
+        final Integer hexInt = Integer.valueOf(hex);
         Vector<IntPair> pairs = numberAndResourceForHex.get(hexInt);
         if (pairs == null)
         {

--- a/src/main/java/soc/message/SOCBoardLayout2.java
+++ b/src/main/java/soc/message/SOCBoardLayout2.java
@@ -197,7 +197,7 @@ public class SOCBoardLayout2 extends SOCMessage
         layoutParts.put("NL", nl);
         if (pl != null)
             layoutParts.put("PL", pl);
-        layoutParts.put("RH", new Integer(rh));
+        layoutParts.put("RH", Integer.valueOf(rh));
     }
 
     /**
@@ -229,9 +229,9 @@ public class SOCBoardLayout2 extends SOCMessage
         if (pl != null)
             layoutParts.put("PL", pl);
         if (rh > 0)
-            layoutParts.put("RH", new Integer(rh));
+            layoutParts.put("RH", Integer.valueOf(rh));
         if (ph > 0)
-            layoutParts.put("PH", new Integer(ph));
+            layoutParts.put("PH", Integer.valueOf(ph));
         if (px != null)
             layoutParts.put("PX", px);
         if (rx != null)

--- a/src/main/java/soc/message/SOCPotentialSettlements.java
+++ b/src/main/java/soc/message/SOCPotentialSettlements.java
@@ -437,7 +437,7 @@ public class SOCPotentialSettlements extends SOCMessage
                     hadNA = true;
                     break;
                 }
-                ps.add(new Integer(Integer.parseInt(tok)));
+                ps.add(Integer.valueOf(Integer.parseInt(tok)));
             }
 
             if (hadNA)
@@ -487,7 +487,7 @@ public class SOCPotentialSettlements extends SOCMessage
                         tok = st.nextToken();
                         if (tok.equals("SE") || tok.startsWith("LA"))
                             break;
-                        ls.add(new Integer(Integer.parseInt(tok)));
+                        ls.add(Integer.valueOf(Integer.parseInt(tok)));
                     }
 
                     las[areaNum] = ls;
@@ -511,7 +511,7 @@ public class SOCPotentialSettlements extends SOCMessage
                             if (edge != 0)
                                 // 0 is used for padding the last SE list if empty;
                                 // otherwise, at the end of the message, an empty list will have no tokens.
-                                lse.add(new Integer(edge));
+                                lse.add(Integer.valueOf(edge));
                         }
 
                         final int L = lse.size();

--- a/src/main/java/soc/robot/OpeningBuildStrategy.java
+++ b/src/main/java/soc/robot/OpeningBuildStrategy.java
@@ -138,7 +138,7 @@ public class OpeningBuildStrategy {
             final int firstNode = ourPotentialSettlements[i];
             // assert: ourPlayerData.isPotentialSettlement(firstNode)
 
-            final Integer firstNodeInt = new Integer(firstNode);
+            final Integer firstNodeInt = Integer.valueOf(firstNode);
 
             //
             // this is just for testing purposes
@@ -336,7 +336,7 @@ public class OpeningBuildStrategy {
         playerNumbers.clear();
         playerNumbers.updateNumbers(firstSettlement, board);
 
-        final Integer firstSettlementInt = new Integer(firstSettlement);
+        final Integer firstSettlementInt = Integer.valueOf(firstSettlement);
 
         for (int portType = SOCBoard.MISC_PORT; portType <= SOCBoard.WOOD_PORT;
                  portType++)
@@ -357,7 +357,7 @@ public class OpeningBuildStrategy {
         playerNumbers.clear();
         playerNumbers.updateNumbers(secondSettlement, board);
 
-        final Integer secondSettlementInt = new Integer(secondSettlement);
+        final Integer secondSettlementInt = Integer.valueOf(secondSettlement);
 
         for (int portType = SOCBoard.MISC_PORT; portType <= SOCBoard.WOOD_PORT;
                  portType++)
@@ -574,7 +574,7 @@ public class OpeningBuildStrategy {
             // each of 6 directions: NE, E, SE, SW, W, NW
             int tmp = board.getAdjacentNodeToNode2Away(settlementNode, facing);
             if ((tmp != -9) && ourPlayerData.canPlaceSettlement(tmp))
-                twoAway.put(new Integer(tmp), new Integer(0));
+                twoAway.put(Integer.valueOf(tmp), Integer.valueOf(0));
         }
 
         scoreNodesForSettlements(twoAway, 3, 5, 10);
@@ -681,7 +681,7 @@ public class OpeningBuildStrategy {
                     /**
                      * remove this spot from the list of best spots
                      */
-                    allNodes.remove(new Integer(bestNodePair.getNode()));
+                    allNodes.remove(Integer.valueOf(bestNodePair.getNode()));
                 }
             }
         }
@@ -821,7 +821,7 @@ public class OpeningBuildStrategy {
              */
             score *= weight;
 
-            nodesIn.put(nodeCoord, new Integer(oldScore + score));
+            nodesIn.put(nodeCoord, Integer.valueOf(oldScore + score));
 
             //log.debug("BSIANS -- put node "+Integer.toHexString(node)+" with old score "+oldScore+" + new score "+score);
         }
@@ -873,7 +873,7 @@ public class OpeningBuildStrategy {
              */
             score *= weight;
 
-            nodesIn.put(nodeCoord, new Integer(oldScore + score));
+            nodesIn.put(nodeCoord, Integer.valueOf(oldScore + score));
 
             //log.debug("BS2AFANS -- put node "+Integer.toHexString(node)+" with old score "+oldScore+" + new score "+score);
         }
@@ -1073,7 +1073,7 @@ public class OpeningBuildStrategy {
              * lowest score is 0
              */
             final int nScore = ((score * 100) / maxScore) * weight;
-            final Integer finalScore = new Integer(nScore + oldScore);
+            final Integer finalScore = Integer.valueOf(nScore + oldScore);
             nodes.put(node, finalScore);
 
             //log.debug("BSN -- put node "+Integer.toHexString(node.intValue())+" with old score "+oldScore+" + new score "+nScore);

--- a/src/main/java/soc/robot/RobberStrategy.java
+++ b/src/main/java/soc/robot/RobberStrategy.java
@@ -207,8 +207,8 @@ public class RobberStrategy
            }
            else
            {
-               SOCPlayerTracker tracker1 = playerTrackers.get(new Integer(i));
-               SOCPlayerTracker tracker2 = playerTrackers.get(new Integer(choice));
+               SOCPlayerTracker tracker1 = playerTrackers.get(Integer.valueOf(i));
+               SOCPlayerTracker tracker2 = playerTrackers.get(Integer.valueOf(choice));
 
                if ((tracker1 != null) && (tracker2 != null) && (tracker1.getWinGameETA() < tracker2.getWinGameETA()))
                {

--- a/src/main/java/soc/robot/SOCPossibleSettlement.java
+++ b/src/main/java/soc/robot/SOCPossibleSettlement.java
@@ -192,7 +192,7 @@ public class SOCPossibleSettlement extends SOCPossiblePiece
            //
            //  get new ports
            //
-           Integer coordInteger = new Integer(this.getCoordinates());
+           Integer coordInteger = Integer.valueOf(this.getCoordinates());
            boolean newPortFlags[] = new boolean[SOCBoard.WOOD_PORT+1];
            for (int port = SOCBoard.MISC_PORT; port <= SOCBoard.WOOD_PORT; port++) {
              newPortFlags[port] = player.getPortFlag(port);

--- a/src/main/java/soc/robot/SOCRobotBrain.java
+++ b/src/main/java/soc/robot/SOCRobotBrain.java
@@ -811,10 +811,10 @@ public class SOCRobotBrain extends Thread
 
             return;
         }
-        if (null == playerTrackers.get(new Integer(pn)))
+        if (null == playerTrackers.get(Integer.valueOf(pn)))
         {
             SOCPlayerTracker tracker = new SOCPlayerTracker(game.getPlayer(pn), this);
-            playerTrackers.put(new Integer(pn), tracker);
+            playerTrackers.put(Integer.valueOf(pn), tracker);
         }
     }
 
@@ -926,14 +926,14 @@ public class SOCRobotBrain extends Thread
         ourPlayerTracker = new SOCPlayerTracker(ourPlayerData, this);
         ourPlayerNumber = ourPlayerData.getPlayerNumber();
         playerTrackers = new HashMap<Integer, SOCPlayerTracker>();
-        playerTrackers.put(new Integer(ourPlayerNumber), ourPlayerTracker);
+        playerTrackers.put(Integer.valueOf(ourPlayerNumber), ourPlayerTracker);
 
         for (int pn = 0; pn < game.maxPlayers; pn++)
         {
             if ((pn != ourPlayerNumber) && ! game.isSeatVacant(pn))
             {
                 SOCPlayerTracker tracker = new SOCPlayerTracker(game.getPlayer(pn), this);
-                playerTrackers.put(new Integer(pn), tracker);
+                playerTrackers.put(Integer.valueOf(pn), tracker);
             }
         }
 

--- a/src/main/java/soc/robot/SOCRobotClient.java
+++ b/src/main/java/soc/robot/SOCRobotClient.java
@@ -876,7 +876,7 @@ public class SOCRobotClient extends SOCDisplaylessPlayerClient
         if (gaOpts != null)
             gameOptions.put(gaName, gaOpts);
 
-        seatRequests.put(gaName, new Integer(mes.getPlayerNumber()));
+        seatRequests.put(gaName, Integer.valueOf(mes.getPlayerNumber()));
         if (put(SOCJoinGame.toCmd(nickname, password, host, gaName)))
         {
             D.ebugPrintln("**** sent SOCJoinGame ****");

--- a/src/main/java/soc/robot/SOCRobotDM.java
+++ b/src/main/java/soc/robot/SOCRobotDM.java
@@ -1267,7 +1267,7 @@ public class SOCRobotDM
             int j = board.getAdjacentEdgeToNode(coord, dir);
             if (pl.isLegalRoad(j))
             {
-                final Integer edge = new Integer(j);
+                final Integer edge = Integer.valueOf(j);
                 boolean match = false;
 
                 for (Enumeration<Integer> ev = visited.elements(); ev.hasMoreElements(); )
@@ -1327,7 +1327,7 @@ public class SOCRobotDM
         else
             rv = 500;
 
-        return new Integer(rv);  // <-- Early return: ! wantsStack ---
+        return Integer.valueOf(rv);  // <-- Early return: ! wantsStack ---
     }
 
     if ((longest > lrLength) && (bestPathNode != null))
@@ -1344,7 +1344,7 @@ public class SOCRobotDM
       List<Integer> nodeList = bestPathNode.getB();
       if ((nodeList == null) || nodeList.isEmpty())
           return null;  // <--- early return, no node list: should not happen ---
-      nodeList.add(new Integer(bestPathNode.getA().node));  // append bestPathNode
+      nodeList.add(Integer.valueOf(bestPathNode.getA().node));  // append bestPathNode
 
       final int L = nodeList.size();
       coordP = nodeList.get(0);  // root ancestor

--- a/src/main/java/soc/robot/SOCRobotNegotiator.java
+++ b/src/main/java/soc/robot/SOCRobotNegotiator.java
@@ -1241,7 +1241,7 @@ public class SOCRobotNegotiator
        ourOriginalFavoriteCity = decisionMaker.getFavoriteCity();
        ourOriginalFavoriteRoad = decisionMaker.getFavoriteRoad();
        ourOriginalPossibleCard = decisionMaker.getPossibleCard();
-       SOCPlayerTracker theirPlayerTracker = (SOCPlayerTracker)playerTrackers.get(new Integer(offer.getFrom()));
+       SOCPlayerTracker theirPlayerTracker = (SOCPlayerTracker)playerTrackers.get(Integer.valueOf(offer.getFrom()));
 
        if (theirPlayerTracker != null) {
        theirOriginalWGETA = theirPlayerTracker.getWinGameETA();

--- a/src/main/java/soc/server/SOCBoardAtServer.java
+++ b/src/main/java/soc/server/SOCBoardAtServer.java
@@ -1067,7 +1067,7 @@ public class SOCBoardAtServer extends SOCBoardLarge
                 // ones placed in previous method calls are ignored
                 Vector<Integer> unvisited = new Vector<Integer>();  // contains each hex's coordinate
                 for (int i = 0; i < landHexType.length; ++i)
-                    unvisited.addElement(new Integer(landPath[i]));
+                    unvisited.addElement(Integer.valueOf(landPath[i]));
 
                 clumpsNotOK = makeNewBoard_checkLandHexResourceClumps(unvisited, clumpSize);
             } else {
@@ -1102,7 +1102,7 @@ public class SOCBoardAtServer extends SOCBoardLarge
         cachedGetLandHexCoords = null;  // invalidate the previous cached set
 
         for (int i = 0; i < landHexType.length; i++)
-            landHexLayout.add(new Integer(landPath[i]));
+            landHexLayout.add(Integer.valueOf(landPath[i]));
 
         for (int i = 0, hexIdx = 0; i < landAreaPathRanges.length; i += 2)
         {

--- a/src/main/java/soc/server/genericServer/Server.java
+++ b/src/main/java/soc/server/genericServer/Server.java
@@ -892,7 +892,7 @@ public abstract class Server extends Thread implements Serializable, Cloneable
      */
     public void clientVersionAdd(final int cvers)
     {
-        Integer cvkey = new Integer(cvers);
+        Integer cvkey = Integer.valueOf(cvers);
         ConnVersionCounter cv = cliVersionsConnected.get(cvkey);
         if (cv == null)
         {
@@ -932,7 +932,7 @@ public abstract class Server extends Thread implements Serializable, Cloneable
      */
     public void clientVersionRem(final int cvers)
     {
-        Integer cvkey = new Integer(cvers);
+        Integer cvkey = Integer.valueOf(cvers);
         ConnVersionCounter cv = cliVersionsConnected.get(cvkey);
         if (cv == null)
         {
@@ -1009,7 +1009,7 @@ public abstract class Server extends Thread implements Serializable, Cloneable
      */
     public boolean isCliVersionConnected(final int cvers)
     {
-        ConnVersionCounter cv = cliVersionsConnected.get(new Integer(cvers));
+        ConnVersionCounter cv = cliVersionsConnected.get(Integer.valueOf(cvers));
         return (cv != null) && (cv.cliCount > 0);
     }
 
@@ -1040,7 +1040,7 @@ public abstract class Server extends Thread implements Serializable, Cloneable
 
             if ((cvkey == null) || (cvers != lastVers))
             {
-                cvkey = new Integer(cvers);
+                cvkey = Integer.valueOf(cvers);
                 cvc = cvmap.get(cvkey);
                 if (cvc == null)
                 {
@@ -1059,7 +1059,7 @@ public abstract class Server extends Thread implements Serializable, Cloneable
 
             if ((cvkey == null) || (cvers != lastVers))
             {
-                cvkey = new Integer(cvers);
+                cvkey = Integer.valueOf(cvers);
                 cvc = cvmap.get(cvkey);
                 if (cvc == null)
                 {


### PR DESCRIPTION
According to the documentation, "Returns a Integer instance representing
the specified int value. If a new Integer instance is not required, this
method should generally be used in preference to the constructor
Integer(int), as this method is likely to yield significantly better
space and time performance by caching frequently requested values."