### PR TITLE
remove redundant method and use of StringBuffer

### DIFF
--- a/src/main/java/soc/message/SOCMessage.java
+++ b/src/main/java/soc/message/SOCMessage.java
@@ -507,20 +507,6 @@ public abstract class SOCMessage implements Serializable, Cloneable
     public abstract String toString();
 
     /**
-     * Utility, get the short simple name of the class: SOCResetBoardVote, not soc.message.SOCResetBoardVote
-     * @return Short name of class, without package name
-     * @since 1.1.01
-     */
-    public String getClassNameShort()
-    {
-        String clName = getClass().getName();
-        int dot = clName.lastIndexOf(".");
-        if (dot > 0)
-            clName = clName.substring(dot + 1);
-        return clName;
-    }
-
-    /**
      * Test whether a string is non-empty and its characters are
      * all 'safe' as a single-line string:
      * No newlines or {@link Character#isISOControl(char) control characters},

--- a/src/main/java/soc/message/SOCMessageTemplate0.java
+++ b/src/main/java/soc/message/SOCMessageTemplate0.java
@@ -107,7 +107,7 @@ public abstract class SOCMessageTemplate0 extends SOCMessage
      */
     public String toString()
     {
-        return getClassNameShort() + ":game=" + game;
+        return getClass().getSimpleName() + ":game=" + game;
     }
 
 }

--- a/src/main/java/soc/message/SOCMessageTemplate1i.java
+++ b/src/main/java/soc/message/SOCMessageTemplate1i.java
@@ -156,6 +156,6 @@ public abstract class SOCMessageTemplate1i extends SOCMessage
      */
     public String toString()
     {
-        return getClassNameShort() + ":game=" + game + "|param=" + p1;
+        return getClass().getSimpleName() + ":game=" + game + "|param=" + p1;
     }
 }

--- a/src/main/java/soc/message/SOCMessageTemplate1s.java
+++ b/src/main/java/soc/message/SOCMessageTemplate1s.java
@@ -156,6 +156,6 @@ public abstract class SOCMessageTemplate1s extends SOCMessage
      */
     public String toString()
     {
-        return getClassNameShort() + ":game=" + game + "|param=" + p1;
+        return getClass().getSimpleName() + ":game=" + game + "|param=" + p1;
     }
 }

--- a/src/main/java/soc/message/SOCMessageTemplate2i.java
+++ b/src/main/java/soc/message/SOCMessageTemplate2i.java
@@ -177,7 +177,7 @@ public abstract class SOCMessageTemplate2i extends SOCMessage
      */
     public String toString()
     {
-        return getClassNameShort() + ":game=" + game
+        return getClass().getSimpleName() + ":game=" + game
             + "|param1=" + p1 + "|param2=" + p2;
     }
 }

--- a/src/main/java/soc/message/SOCMessageTemplate2s.java
+++ b/src/main/java/soc/message/SOCMessageTemplate2s.java
@@ -180,7 +180,7 @@ public abstract class SOCMessageTemplate2s extends SOCMessage
      */
     public String toString()
     {
-        return getClassNameShort() + ":game=" + game
+        return getClass().getSimpleName() + ":game=" + game
             + "|param1=" + p1
             + "|param2=" + (p2 != null ? p2 : "");
     }

--- a/src/main/java/soc/message/SOCMessageTemplate3i.java
+++ b/src/main/java/soc/message/SOCMessageTemplate3i.java
@@ -197,7 +197,7 @@ public abstract class SOCMessageTemplate3i extends SOCMessage
      */
     public String toString()
     {
-        return getClassNameShort() + ":game=" + game
+        return getClass().getSimpleName() + ":game=" + game
             + "|param1=" + p1 + "|param2=" + p2 + "|param3=" + p3;
     }
 }

--- a/src/main/java/soc/message/SOCMessageTemplate3s.java
+++ b/src/main/java/soc/message/SOCMessageTemplate3s.java
@@ -201,7 +201,7 @@ public abstract class SOCMessageTemplate3s extends SOCMessage
      */
     public String toString()
     {
-        return getClassNameShort() + ":game=" + game
+        return this.getClass().getSimpleName() + ":game=" + game
             + "|param1=" + p1
             + "|param2=" + (p2 != null ? p2 : "")
             + "|param3=" + (p3 != null ? p3 : "");

--- a/src/main/java/soc/message/SOCMessageTemplate4i.java
+++ b/src/main/java/soc/message/SOCMessageTemplate4i.java
@@ -219,7 +219,7 @@ public abstract class SOCMessageTemplate4i extends SOCMessage
      */
     public String toString()
     {
-        return getClassNameShort() + ":game=" + game
+        return getClass().getSimpleName() + ":game=" + game
             + "|param1=" + p1 + "|param2=" + p2
             + "|param3=" + p3 + "|param4=" + p4;
     }

--- a/src/main/java/soc/message/SOCMessageTemplateMi.java
+++ b/src/main/java/soc/message/SOCMessageTemplateMi.java
@@ -186,7 +186,7 @@ public abstract class SOCMessageTemplateMi extends SOCMessageMulti
      */
     public String toString()
     {
-        StringBuffer sb = new StringBuffer(getClassNameShort());
+        StringBuilder sb = new StringBuilder(getClass().getSimpleName());
         if (game != null)
         {
             sb.append (":game=");

--- a/src/main/java/soc/message/SOCMessageTemplateMs.java
+++ b/src/main/java/soc/message/SOCMessageTemplateMs.java
@@ -195,7 +195,7 @@ public abstract class SOCMessageTemplateMs extends SOCMessageMulti
      */
     public String toString()
     {
-        StringBuilder sb = new StringBuilder(getClassNameShort());
+        StringBuilder sb = new StringBuilder(getClass().getSimpleName());
 
         if (pa != null)
         {

--- a/src/main/java/soc/message/SOCSVPTextMessage.java
+++ b/src/main/java/soc/message/SOCSVPTextMessage.java
@@ -175,7 +175,7 @@ public class SOCSVPTextMessage extends SOCMessage
      */
     public String toString()
     {
-        return getClassNameShort() + ":game=" + game
+        return getClass().getSimpleName() + ":game=" + game
             + "|pn=" + pn + "|svp=" + svp + "|desc=" + desc;
     }
 


### PR DESCRIPTION
remove redundant method to get class simple name and use the one baked into Java. 
Use StringBuilder over StringBuffer